### PR TITLE
Correct use_saved_calibration parameter

### DIFF
--- a/OLD_README.md
+++ b/OLD_README.md
@@ -185,7 +185,8 @@ def RunMe(sessionID=None,
         resetBlenderExe = False,
       	get_synced_unix_timestamps = True,
         good_clean_frame_number = 0,
-        bundle_adjust_3d_points=False
+        bundle_adjust_3d_points=False,
+	use_saved_calibration = False,
         ):
 ```
 
@@ -302,7 +303,7 @@ def RunMe(sessionID=None,
   -  [Default] = False,
   -  When set to `True`, the system will run a bundle adjust optimization of all recorded 3d points produced in `stage=4` using `aniposelib`'s `optim_points` method. This takes a rather long time, but can signicantly clean up the resulting recordings. However,it may also "over smooth" the data. We're in the process of testing this method out now
   
-- `use_previous_calibration`
+- `use_saved_calibration`
   - [Type]  = BOOL
   -  [Default] = False,
   -  Choose whether to use a calibration file from a previous session. When `False`, FreeMoCap will automatically save out calibration data whenever stage 3 is successfully completed. Only one saved calibration file is stored, so running another session will overwrite the currently saved calibration file. When `True` , FreeMoCap will instead load in the saved calibration data, which allows users to create recordings without needing to show the cameras the Charuco board. 


### PR DESCRIPTION
OLD_README.md currently refers to the parameter `use_previous_calibration`, but the correct parameter name is `use_saved_calibration`. Using the wrong parameter name gives the error `TypeError: RunMe() got an unexpected keyword argument 'use_previous_calibration'`. This PR changes the existing parameter reference to the correct word, and adds the parameter to the default parameter list. 

There have been multiple Discord questions around this, so even though this PR will be outdated soon due to the Alpha release, it may save some time while pre-alpha is still in use.