### PR TITLE
add `opencv-contrib-python==4.6.0.66`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ mkdocs-material==8.3.9
 qtconsole==5.3.0
 qtpy==2.0.1
 rich==12.6.0
+opencv-contrib-python==4.6.0.66


### PR DESCRIPTION
apparently we weren't explicitly installing `opencv-contrib-python` which is necessary for the `charuco` board calibration. 

I think we lost it when we dropped the `anipose` requirement. 
