### PR TITLE
Fix video loading behavior on Mac/Linux

### DIFF
--- a/src/blender_stuff/alpha_freemocap_blender_megascript.py
+++ b/src/blender_stuff/alpha_freemocap_blender_megascript.py
@@ -4,6 +4,8 @@ import numpy as np
 from pathlib import Path
 import sys
 
+from src.utils.get_video_files import get_video_files
+
 print(" - Starting (alpha) blender megascript - ")
 
 #######################################################################
@@ -1673,14 +1675,14 @@ try:
 
             world_origin = bpy.data.objects["world_origin"]
 
-            number_of_videos = len(list(vidFolderPath.glob("*.mp4")))
+            number_of_videos = len(get_video_files(vidFolderPath))
 
             vid_location_scale = 1
 
             for (
                 vid_number,
                 thisVidPath,
-            ) in enumerate(vidFolderPath.glob("*.mp4")):
+            ) in enumerate(get_video_files(vidFolderPath)):
                 print(thisVidPath)
                 # use 'images as planes' add on to load in the video files as planes
                 bpy.ops.import_image.to_plane(

--- a/src/blender_stuff/bind_rigify_meta_rig_to_freemocap_data.py
+++ b/src/blender_stuff/bind_rigify_meta_rig_to_freemocap_data.py
@@ -9,6 +9,8 @@ import json
 
 import sys
 
+from src.utils.get_video_files import get_video_files
+
 print("Running script to create Blender file from freemocap session data: " + __file__)
 ###############################################################
 ### parse arguments from command line
@@ -824,14 +826,14 @@ try:
 
     world_origin = bpy.data.objects["world_origin"]
 
-    number_of_videos = len(list(video_folder_path.glob("*.mp4")))
+    number_of_videos = len(get_video_files(video_folder_path))
 
     vid_location_scale = 1
 
     for (
         vid_number,
         thisVidPath,
-    ) in enumerate(video_folder_path.glob("*.mp4")):
+    ) in enumerate(get_video_files(video_folder_path)):
         print(thisVidPath)
         # use 'images as planes' add on to load in the video files as planes
         bpy.ops.import_image.to_plane(

--- a/src/blender_stuff/old/bind_mixamo_rig_to_freemocap_mocap_data.py
+++ b/src/blender_stuff/old/bind_mixamo_rig_to_freemocap_mocap_data.py
@@ -3,6 +3,8 @@ import numpy as np
 from pathlib import Path
 import json
 
+from src.utils.get_video_files import get_video_files
+
 #####################################################################
 ###%% clear the scene - Scorch the earth \o/
 print("clearing scene")
@@ -63,14 +65,14 @@ try:
 
     world_origin = bpy.data.objects["world_origin"]
 
-    number_of_videos = len(list(vidFolderPath.glob("*.mp4")))
+    number_of_videos = len(get_video_files(vidFolderPath))
 
     vid_location_scale = 1
 
     for (
         vid_number,
         thisVidPath,
-    ) in enumerate(vidFolderPath.glob("*.mp4")):
+    ) in enumerate(get_video_files(vidFolderPath)):
         print(thisVidPath)
         # use 'images as planes' add on to load in the video files as planes
         bpy.ops.import_image.to_plane(

--- a/src/core_processes/mediapipe_stuff/mediapipe_skeleton_detector.py
+++ b/src/core_processes/mediapipe_stuff/mediapipe_skeleton_detector.py
@@ -18,6 +18,7 @@ from src.core_processes.mediapipe_stuff.medaipipe_tracked_points_names_dict impo
 from src.core_processes.batch_processing.session_processing_parameter_models import (
     MediaPipe2DParametersModel,
 )
+from src.utils.get_video_files import get_video_files
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +177,7 @@ class MediaPipeSkeletonDetector:
 
         mediapipe2d_single_camera_npy_arrays_list = []
         for video_number, this_synchronized_video_file_path in enumerate(
-            path_to_folder_of_videos_to_process.glob("*.mp4")
+            get_video_files(path_to_folder_of_videos_to_process)
         ):
             logger.info(
                 f"Running `mediapipe` skeleton detection on  video: {str(this_synchronized_video_file_path)}"

--- a/src/gui/main/main_window/main_window.py
+++ b/src/gui/main/main_window/main_window.py
@@ -66,6 +66,8 @@ from src.sending_anonymous_user_info_to_places.send_pipedream_ping import (
     send_pipedream_ping,
 )
 
+from src.utils.get_video_files import get_video_files
+
 # reboot GUI method based on this - https://stackoverflow.com/a/56563926/14662833
 EXIT_CODE_REBOOT = -123456789
 
@@ -508,7 +510,7 @@ class MainWindow(QMainWindow):
             f"Copying videos from {external_videos_path} to {synchronized_videos_folder_path}"
         )
 
-        for video_path in Path(external_videos_path).glob("*.mp4"):
+        for video_path in get_video_files(Path(external_videos_path)):
             shutil.copy(video_path, synchronized_videos_folder_path)
 
         self._start_session(self._session_id)
@@ -650,7 +652,7 @@ class MainWindow(QMainWindow):
         )
         if (
             not Path(calibration_videos_folder_path).exists()
-            or len(list(Path(calibration_videos_folder_path).glob("*.mp4"))) == 0
+            or len(get_video_files(Path(calibration_videos_folder_path))) == 0
         ):
             logger.info(
                 f"Calibration videos folder does not exist (or its empty): {calibration_videos_folder_path}, copying vidoes from `synchronized_videos` to `calibration_videos` and trying with that"
@@ -856,10 +858,8 @@ class MainWindow(QMainWindow):
             / MEDIAPIPE_3D_ORIGIN_ALIGNED_NPY_FILE_NAME
         )
 
-        video_path_iterator = Path(
-            get_annotated_videos_folder_path(self._session_id)
-        ).glob("*.mp4".lower())
-        list_of_video_paths = [str(video_path) for video_path in video_path_iterator]
+        list_of_video_path_objects = get_video_files(get_annotated_videos_folder_path(self._session_id))
+        list_of_video_paths = [str(video_path) for video_path in list_of_video_path_objects]
 
         dictionary_of_video_image_update_callbacks = (
             self._middle_viewing_panel.dictionary_of_video_image_update_callbacks

--- a/src/tests/test_mediapipe_data.py
+++ b/src/tests/test_mediapipe_data.py
@@ -9,7 +9,7 @@ from src.config.home_dir import (
     MEDIAPIPE_REPROJECTION_ERROR_NPY_FILE_NAME,
     MEDIAPIPE_2D_NPY_FILE_NAME,
 )
-
+from src.utils.get_video_files import get_video_files
 
 def test_mediapipe_2d_data(
     synchronized_videos_folder: Union[str, Path],
@@ -34,7 +34,7 @@ def test_mediapipe_2d_data(
     saved_mediapipe_2d_data = np.load(mediapipe_2d_data_file_path)
     assert np.array_equal(saved_mediapipe_2d_data, mediapipe_2d_data, equal_nan=True)
 
-    list_of_video_paths = list(synchronized_videos_folder.glob("*.mp4"))
+    list_of_video_paths = get_video_files(synchronized_videos_folder)
     number_of_videos = len(list_of_video_paths)
     assert mediapipe_2d_data.shape[0] == number_of_videos
 
@@ -87,7 +87,7 @@ def test_mediapipe_3d_data(
         saved_reprojection_error, skeleton_reprojection_error_fr_mar, equal_nan=True
     )
 
-    list_of_video_paths = list(synchronized_videos_folder.glob("*.mp4"))
+    list_of_video_paths = get_video_files(synchronized_videos_folder)
 
     video_0_cv2_capture_object = cv2.VideoCapture(str(list_of_video_paths[0]))
 

--- a/src/utils/get_video_files.py
+++ b/src/utils/get_video_files.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+def create_list_of_video_paths(path_to_video_folder: Path) -> list:
+    '''Search the folder for 'mp4' files (case insensitive) and return them as a list'''
+
+    list_of_video_paths = list(Path(path_to_video_folder).glob('*.mp4')) + list(Path(path_to_video_folder).glob('*.MP4'))
+    unique_list_of_video_paths = get_unique_list(list_of_video_paths)
+
+    return unique_list_of_video_paths
+
+def get_unique_list(list: list) -> list:
+    '''Return a list of the unique elements from input list'''
+    unique_list = []
+    [unique_list.append(clip) for clip in list if clip not in unique_list]
+
+    return unique_list

--- a/src/utils/get_video_files.py
+++ b/src/utils/get_video_files.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
-def create_list_of_video_paths(path_to_video_folder: Path) -> list:
-    '''Search the folder for 'mp4' files (case insensitive) and return them as a list'''
+def get_video_files(path_to_video_folder: Path) -> list:
+    '''Search the folder for 'mp4' files (case insensitive) and return a list of their paths'''
 
-    list_of_video_paths = list(Path(path_to_video_folder).glob('*.mp4')) + list(Path(path_to_video_folder).glob('*.MP4'))
+    list_of_video_paths = list(Path(path_to_video_folder).glob("*.mp4")) + list(Path(path_to_video_folder).glob("*.MP4"))
     unique_list_of_video_paths = get_unique_list(list_of_video_paths)
 
     return unique_list_of_video_paths


### PR DESCRIPTION
The current video loading behavior looks for video files in a path by doing a glob search `video_path.glob("*.mp4")`. This method of searching is case insensitive on windows, but case sensitive on Mac/Linux. The problem is described more fully in the issue linked below.

This PR creates a module `get_video_files.py` with a `get_video_files()` function that is called wherever `.glob("*.mp4")` was used.

Closes #288 