### PR TITLE
Fix blender executable path input on mac

### DIFF
--- a/freemocap/gui/qt/widgets/control_panel/visualization_control_panel.py
+++ b/freemocap/gui/qt/widgets/control_panel/visualization_control_panel.py
@@ -96,6 +96,8 @@ class VisualizationControlPanel(QWidget):
 
         if "blender." in path_selection[0]:
             self._blender_executable_path = path_selection[0]
+        elif "blender." or "Blender" in self._blender_executable_label.text():
+            self._blender_executable_path = self._blender_executable_label.text()
         else:
             self._blender_executable_path = BLENDER_EXECUTABLE_PATH_MISSING_STRING
 

--- a/freemocap/gui/qt/widgets/control_panel/visualization_control_panel.py
+++ b/freemocap/gui/qt/widgets/control_panel/visualization_control_panel.py
@@ -96,7 +96,7 @@ class VisualizationControlPanel(QWidget):
 
         if "blender." in path_selection[0]:
             self._blender_executable_path = path_selection[0]
-        elif "blender." or "Blender" in self._blender_executable_label.text():
+        elif "blender." in self._blender_executable_label.text() or "MacOS/Blender" in self._blender_executable_label.text():
             self._blender_executable_path = self._blender_executable_label.text()
         else:
             self._blender_executable_path = BLENDER_EXECUTABLE_PATH_MISSING_STRING

--- a/freemocap/gui/qt/widgets/control_panel/visualization_control_panel.py
+++ b/freemocap/gui/qt/widgets/control_panel/visualization_control_panel.py
@@ -96,8 +96,8 @@ class VisualizationControlPanel(QWidget):
 
         if "blender." in path_selection[0]:
             self._blender_executable_path = path_selection[0]
-        elif "blender." in self._blender_executable_label.text() or "MacOS/Blender" in self._blender_executable_label.text():
-            self._blender_executable_path = self._blender_executable_label.text()
+        elif "Blender.app" in path_selection[0]:
+            self._blender_executable_path = path_selection[0] + "/Contents/MacOS/Blender" # executable is buried on mac
         else:
             self._blender_executable_path = BLENDER_EXECUTABLE_PATH_MISSING_STRING
 


### PR DESCRIPTION
A hot fix allowing the path to an executable to be found by the file dialog widget, fixing the issue brought up on discord [here](https://discord.com/channels/760487252379041812/760489602917466133/1087385656134729758), where the blender executable is not directly accessible on macs.

If the selected file pathstring contains "Blender.app", as it does on mac, the widget adds `/Contents/MacOS/Blender` to the end of the pathstring. This points to the correct location of the executable inside the app, which is usually hidden from mac users and unlikely to be different between users/versions of blender.