### PR TITLE
need to grab JUST x and y for 3D triangulation

### DIFF
--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
@@ -104,7 +104,7 @@ def process_recording_folder(
         )
         (raw_skel3d_frame_marker_xyz, skeleton_reprojection_error_fr_mar,) = triangulate_3d_data(
             anipose_calibration_object=anipose_calibration_object,
-            mediapipe_2d_data=mediapipe_image_data_numCams_numFrames_numTrackedPts_XYZ,
+            mediapipe_2d_data=mediapipe_image_data_numCams_numFrames_numTrackedPts_XYZ[:, :, :, :2],
             output_data_folder_path=rec.recording_info_model.raw_data_folder_path,
             mediapipe_confidence_cutoff_threshold=rec.anipose_triangulate_3d_parameters_model.confidence_threshold_cutoff,
             use_triangulate_ransac=rec.anipose_triangulate_3d_parameters_model.use_triangulate_ransac_method,


### PR DESCRIPTION
When we feed mediapipe into the triangulation method, we need to just feed it the x and y. Single camera adds a Z dimension to the basic data format. Somehow, when I tested this wasn't an issue (which means I probably didn't test a 3D multi camera calibration with the single camera mode; oops)