### PR TITLE
Trent/better pipedream pings

### DIFF
--- a/freemocap/gui/qt/main_window/freemocap_main_window.py
+++ b/freemocap/gui/qt/main_window/freemocap_main_window.py
@@ -334,6 +334,8 @@ class FreemocapMainWindow(QMainWindow):
         logger.info(f"New active recording selected: {recording_info_model.path}")
 
         # self._calibration_control_panel.update_calibrate_from_active_recording_button_text()
+        self._pipedream_pings.update_pings_dict(key=recording_info_model.name,
+                                                value=self._active_recording_info_widget.active_recording_info.status_check)
 
         path = Path(recording_info_model.path)
         path.mkdir(parents=True, exist_ok=True)
@@ -481,7 +483,8 @@ class FreemocapMainWindow(QMainWindow):
         logger.info("Main window `closeEvent` detected")
 
         self._pipedream_pings.update_pings_dict(key="gui_closed", value=True)
-        self._pipedream_pings.update_pings_dict(key="active recording status on close", value=self._active_recording_info_widget.active_recording_info.status_check)
+        self._pipedream_pings.update_pings_dict(key="active recording status on close",
+                                                value=self._active_recording_info_widget.active_recording_info.status_check)
         self._pipedream_pings.send_pipedream_ping()
 
         remove_empty_directories(get_recording_session_folder_path())

--- a/freemocap/parameter_info_models/recording_info_model.py
+++ b/freemocap/parameter_info_models/recording_info_model.py
@@ -210,10 +210,10 @@ class RecordingFolderStatusChecker:
         return Path(self.recording_info_model.calibration_toml_path).is_file()
 
     def get_number_of_mp4s_in_synched_videos_directory(self) -> float:
-        synch_directory_path = Path(self.recording_info_model.synchronized_videos_folder_path)
+        synchronized_directory_path = Path(self.recording_info_model.synchronized_videos_folder_path)
         video_count = 0.0
 
-        for file in synch_directory_path.iterdir():
+        for file in synchronized_directory_path.iterdir():
             if file.is_file() and file.suffix.lower() == '.mp4':
                 video_count += 1
 

--- a/freemocap/parameter_info_models/recording_info_model.py
+++ b/freemocap/parameter_info_models/recording_info_model.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Union, Dict
+from typing import Union, Dict, Any
 
 from freemocap.system.paths_and_files_names import (
     CENTER_OF_MASS_FOLDER_NAME,
@@ -145,13 +145,16 @@ class RecordingFolderStatusChecker:
         self.recording_info_model = recording_info_model
 
     @property
-    def status_check(self) -> Dict[str, bool]:
+    def status_check(self) -> Dict[str, Union[bool, str, float]]:
         return {
             'synchronized_videos_status_check': self.check_synchronized_videos_status(),
             'data2d_status_check': self.check_data2d_status(),
             'data3d_status_check': self.check_data3d_status(),
             'center_of_mass_data_status_check': self.check_center_of_mass_data_status(),
             'blender_file_status_check': self.check_blender_file_status(), }
+            # number of cameras
+            # number of frames
+            # mean of reprojection error
 
     def check_synchronized_videos_status(self) -> bool:
         try:


### PR DESCRIPTION
I've added a function that gets the number of synchronized videos and the number of frames in each video and puts it in the pinged dictionary as a part of the pipedream pipeline.

I would also like to send along the camera rotations and translation (position) information, which needs to be scraped out of the calibration toml. I'm currently having issues with accessing the correct path to the toml; within RecordingModelInfo, self.calibration_toml_path points to a path that doesn't exist. 