### PR TITLE
Add help and support menus

### DIFF
--- a/freemocap/gui/qt/actions_and_menus/actions.py
+++ b/freemocap/gui/qt/actions_and_menus/actions.py
@@ -1,4 +1,5 @@
-from PyQt6.QtGui import QAction
+from PyQt6.QtGui import QAction, QDesktopServices
+from PyQt6.QtCore import QUrl
 
 
 CREATE_NEW_RECORDING_ACTION_NAME = "New Recording"
@@ -8,6 +9,11 @@ IMPORT_VIDEOS_ACTION_NAME = "Import Videos"
 KILL_THREADS_AND_PROCESSES_ACTION_NAME = "Kill Threads and Processes"
 REBOOT_GUI_ACTION_NAME = "Reboot GUI"
 EXIT_ACTION_NAME = "Exit"
+
+DOCUMENTATION_ACTION_NAME = "Open Documentation"
+ABOUT_US_ACTION_NAME = "About Us"
+
+DONATE_ACTION_NAME = "Donate to Freemocap"
 
 
 class Actions:
@@ -49,10 +55,12 @@ class Actions:
         self.exit_action.setShortcut("Ctrl+Q")
         self.exit_action.triggered.connect(freemocap_main_window.close)
 
-        # # Help
-        # open_docs_action = QAction("Open  &Documentation", parent=main_window)
-        # about_us_action = QAction("&About Us", parent=main_window)
-        #
+        # Help
+        self.open_docs_action = QAction(DOCUMENTATION_ACTION_NAME, parent=freemocap_main_window)
+        self.open_docs_action.triggered.connect(lambda: QDesktopServices.openUrl(QUrl("https://freemocap.readthedocs.io/en/latest/")))
+        
+        self.about_us_action = QAction(ABOUT_US_ACTION_NAME, parent=freemocap_main_window)
+
         # # Navigation
         # show_camera_control_panel_action = QAction("&1 - Show Camera Control Panel", parent=main_window)
         # show_camera_control_panel_action.setShortcut("Ctrl+1")
@@ -65,7 +73,8 @@ class Actions:
         # show_motion_capture_videos_panel_action = QAction("&3 - Show Motion Capture Videos Panel", parent=main_window)
         # show_motion_capture_videos_panel_action.setShortcut("Ctrl+3")
         #
-        # # Support
-        # donate_action = QAction("&Donate", parent=main_window)
-        # send_usage_statistics_action = QAction("Send &User Statistics", parent=main_window)
-        # user_survey_action = QAction("&User Survey", parent=main_window)
+        # Support
+        self.donate_action = QAction(DONATE_ACTION_NAME, parent=freemocap_main_window)
+        self.donate_action.triggered.connect(lambda: QDesktopServices.openUrl(QUrl("https://freemocap.org/about-us.html#donate")))
+        # self.send_usage_statistics_action = QAction("Send &User Statistics", parent=freemocap_main_window)
+        # self.user_survey_action = QAction("&User Survey", parent=freemocap_main_window)

--- a/freemocap/gui/qt/actions_and_menus/actions.py
+++ b/freemocap/gui/qt/actions_and_menus/actions.py
@@ -60,6 +60,7 @@ class Actions:
         self.open_docs_action.triggered.connect(lambda: QDesktopServices.openUrl(QUrl("https://freemocap.readthedocs.io/en/latest/")))
         
         self.about_us_action = QAction(ABOUT_US_ACTION_NAME, parent=freemocap_main_window)
+        self.about_us_action.triggered.connect(lambda: QDesktopServices.openUrl(QUrl("https://freemocap.org/about-us.html")))
 
         # # Navigation
         # show_camera_control_panel_action = QAction("&1 - Show Camera Control Panel", parent=main_window)

--- a/freemocap/gui/qt/actions_and_menus/actions.py
+++ b/freemocap/gui/qt/actions_and_menus/actions.py
@@ -10,7 +10,7 @@ KILL_THREADS_AND_PROCESSES_ACTION_NAME = "Kill Threads and Processes"
 REBOOT_GUI_ACTION_NAME = "Reboot GUI"
 EXIT_ACTION_NAME = "Exit"
 
-DOCUMENTATION_ACTION_NAME = "Open Documentation"
+OPEN_DOCS_ACTION_NAME = "Open Documentation"
 ABOUT_US_ACTION_NAME = "About Us"
 
 DONATE_ACTION_NAME = "Donate to Freemocap"

--- a/freemocap/gui/qt/actions_and_menus/actions.py
+++ b/freemocap/gui/qt/actions_and_menus/actions.py
@@ -11,7 +11,7 @@ REBOOT_GUI_ACTION_NAME = "Reboot GUI"
 EXIT_ACTION_NAME = "Exit"
 
 OPEN_DOCS_ACTION_NAME = "Open Documentation"
-ABOUT_US_ACTION_NAME = "About Us"
+FREEMOCAP_FOUNDATION_ACTION_NAME = "Freemocap Foundation"
 
 DONATE_ACTION_NAME = "Donate to Freemocap"
 
@@ -56,11 +56,11 @@ class Actions:
         self.exit_action.triggered.connect(freemocap_main_window.close)
 
         # Help
-        self.open_docs_action = QAction(DOCUMENTATION_ACTION_NAME, parent=freemocap_main_window)
+        self.open_docs_action = QAction(OPEN_DOCS_ACTION_NAME, parent=freemocap_main_window)
         self.open_docs_action.triggered.connect(lambda: QDesktopServices.openUrl(QUrl("https://freemocap.readthedocs.io/en/latest/")))
         
-        self.about_us_action = QAction(ABOUT_US_ACTION_NAME, parent=freemocap_main_window)
-        self.about_us_action.triggered.connect(lambda: QDesktopServices.openUrl(QUrl("https://freemocap.org/about-us.html")))
+        self.freemocap_foundation_action = QAction(FREEMOCAP_FOUNDATION_ACTION_NAME, parent=freemocap_main_window)
+        self.freemocap_foundation_action.triggered.connect(lambda: QDesktopServices.openUrl(QUrl("https://freemocap.org/about-us.html")))
 
         # # Navigation
         # show_camera_control_panel_action = QAction("&1 - Show Camera Control Panel", parent=main_window)

--- a/freemocap/gui/qt/actions_and_menus/menu_bar.py
+++ b/freemocap/gui/qt/actions_and_menus/menu_bar.py
@@ -1,5 +1,6 @@
 from PyQt6.QtWidgets import QMainWindow, QMenuBar
-
+from PyQt6.QtGui import QAction, QDesktopServices
+from PyQt6.QtCore import QUrl
 from freemocap.gui.qt.actions_and_menus.actions import Actions
 
 
@@ -33,24 +34,18 @@ class MenuBar(QMenuBar):
         # navigation_menu.addAction(self._show_calibrate_capture_volume_panel_action)
         # navigation_menu.addAction(self._show_motion_capture_videos_panel_action)
         #
-        # # help menu
-        # help_menu = QMenu("&Help", parent=self)
-        # self.addMenu(help_menu)
-        # help_menu.setEnabled(False)
+        # help menu
+        help_menu = self.addMenu("&Help")
+
+        help_menu.addAction(actions.open_docs_action)
+        help_menu.addAction(actions.about_us_action)
         #
-        # help_menu.addAction(self._open_docs_action)
-        # help_menu.addAction(self._about_us_action)
-        #
-        # # support menu
-        # support_menu = QMenu(
-        #     "\U00002665 &Support the FreeMoCap Project", parent=self
-        # )
-        # support_menu.setEnabled(False)
-        # self.addMenu(support_menu)
-        #
-        # support_menu.addAction(self._donate_action)
-        # support_menu.addAction(self._send_usage_statistics_action)
-        # support_menu.addAction(self._user_survey_action)
+        # support menu
+        support_menu = self.addMenu("&Support the Freemocap Project")
+   
+        support_menu.addAction(actions.donate_action)
+        # support_menu.addAction(actions.send_usage_statistics_action)
+        # support_menu.addAction(actions.user_survey_action)
 
 
 if __name__ == "__main__":

--- a/freemocap/gui/qt/actions_and_menus/menu_bar.py
+++ b/freemocap/gui/qt/actions_and_menus/menu_bar.py
@@ -36,7 +36,7 @@ class MenuBar(QMenuBar):
         help_menu = self.addMenu("&Help")
 
         help_menu.addAction(actions.open_docs_action)
-        help_menu.addAction(actions.about_us_action)
+        help_menu.addAction(actions.freemocap_foundation_action)
         #
         # support menu
         support_menu = self.addMenu("&Support the Freemocap Project")

--- a/freemocap/gui/qt/actions_and_menus/menu_bar.py
+++ b/freemocap/gui/qt/actions_and_menus/menu_bar.py
@@ -1,6 +1,4 @@
 from PyQt6.QtWidgets import QMainWindow, QMenuBar
-from PyQt6.QtGui import QAction, QDesktopServices
-from PyQt6.QtCore import QUrl
 from freemocap.gui.qt.actions_and_menus.actions import Actions
 
 

--- a/freemocap/gui/qt/widgets/home_widget.py
+++ b/freemocap/gui/qt/widgets/home_widget.py
@@ -69,10 +69,15 @@ class HomeWidget(QWidget):
 
         self._layout.addStretch(1)
 
-        send_pings_string = "Send ping to devs to let us know when you make a new session (being able to show that people are using this thing will help us get funding for this project :D )"
+        send_pings_string = "Send anonymous usage information"
         self._send_pings_checkbox = QCheckBox(send_pings_string)
         self._send_pings_checkbox.setChecked(True)
-        self._layout.addWidget(self._send_pings_checkbox)
+        self._layout.addWidget(self._send_pings_checkbox, alignment=Qt.AlignmentFlag.AlignCenter)
+
+        privacy_policy_link_string = '<a href="https://freemocap.readthedocs.io/en/latest/privacy_policy/" style="color: white;">Click here to view our privacy policy</a>'
+        self._privacy_policy_link = QLabel(privacy_policy_link_string)
+        self._privacy_policy_link.setOpenExternalLinks(True)
+        self._layout.addWidget(self._privacy_policy_link, alignment=Qt.AlignmentFlag.AlignCenter)
 
         self.style().polish(self)
 


### PR DESCRIPTION
This pull request adds help and support tabs back to the menubar. It uses the old commented out code, but updates it to match the style of the currently-in-use file menu. 

I was not able to find any way to have the support option be a button instead of a drop down ([this solution doesn't work](https://stackoverflow.com/questions/52986172/pyqt-about-button-in-menu-bar)).
Also, because of how Macs handle the menubar, an option that starts with the text "About" will not show up (it should show on windows). We can either change the text ("Freemocap - About Us", for example) or be content with it not showing up on mac.

<img width="1491" alt="Screen Shot 2023-04-04 at 12 10 51 PM" src="https://user-images.githubusercontent.com/24758117/229880987-9174a1f2-608b-4778-8550-783281be1561.png">
<img width="630" alt="Screen Shot 2023-04-04 at 12 10 57 PM" src="https://user-images.githubusercontent.com/24758117/229881017-c88fff70-dc56-42ab-b5ad-b95e7951d6eb.png">
<img width="592" alt="Screen Shot 2023-04-04 at 12 11 03 PM" src="https://user-images.githubusercontent.com/24758117/229881042-cfe0fc5e-f7f7-4755-81aa-f81bad39db34.png">
