### PR TITLE
Add camera lag note

### DIFF
--- a/freemocap/gui/qt/widgets/camera_controller_group_box.py
+++ b/freemocap/gui/qt/widgets/camera_controller_group_box.py
@@ -70,7 +70,7 @@ class CameraControllerGroupBox(QGroupBox):
 
         vbox.addLayout(hbox)
 
-        lag_note_label = QLabel("NOTE: Use fewer cameras or decrease resolution if you are experiecing lag")
+        lag_note_label = QLabel("NOTE: Use fewer cameras or decrease resolution if you are experiencing lag")
         vbox.addWidget(lag_note_label)
 
         return vbox

--- a/freemocap/gui/qt/widgets/camera_controller_group_box.py
+++ b/freemocap/gui/qt/widgets/camera_controller_group_box.py
@@ -50,6 +50,8 @@ class CameraControllerGroupBox(QGroupBox):
         self._layout.addWidget(self._skellycam_controller)
 
     def _create_videos_will_save_to_layout(self):
+        vbox = QVBoxLayout()
+
         hbox = QHBoxLayout()
         self._recording_string_tag_line_edit = QLineEdit(parent=self)
         self._recording_string_tag_line_edit.setPlaceholderText("(Optional)")
@@ -65,7 +67,13 @@ class CameraControllerGroupBox(QGroupBox):
         self._recording_path_label = QLabel(f"{self.get_new_recording_path()}")
         self._recording_path_label.setStyleSheet("font-family: monospace; font-size: 10px;")
         hbox.addWidget(self._recording_path_label)
-        return hbox
+
+        vbox.addLayout(hbox)
+
+        lag_note_label = QLabel("NOTE: Use fewer cameras or decrease resolution if you are experiecing lag")
+        vbox.addWidget(lag_note_label)
+
+        return vbox
 
     def _create_mocap_recording_option_layout(self):
         hbox = QHBoxLayout()

--- a/freemocap/gui/qt/widgets/camera_controller_group_box.py
+++ b/freemocap/gui/qt/widgets/camera_controller_group_box.py
@@ -70,7 +70,7 @@ class CameraControllerGroupBox(QGroupBox):
 
         vbox.addLayout(hbox)
 
-        lag_note_label = QLabel("NOTE: Use fewer cameras or decrease resolution if you are experiencing lag")
+        lag_note_label = QLabel("NOTE: If you experience frame lag, decrease the resolution or use fewer cameras. We are working on a fix for this")
         vbox.addWidget(lag_note_label)
 
         return vbox


### PR DESCRIPTION
Adds a note in the camera controller groupbox that says "NOTE: Use fewer cameras or decrease resolution if you are experiencing lag"

<img width="860" alt="Screen Shot 2023-04-04 at 12 50 28 PM" src="https://user-images.githubusercontent.com/24758117/229891269-7cf8c1dc-2163-402a-b25f-fe1d598dd85d.png">
