### PR TITLE
Color contrast improvements

### DIFF
--- a/freemocap/gui/qt/style_sheet/qt_style_sheet.css
+++ b/freemocap/gui/qt/style_sheet/qt_style_sheet.css
@@ -1,4 +1,3 @@
- /* If you want to update the appearance of the GUI, please make changes to the `qt_stylesheet.scss` file. */
 * {
   font-family: "Dosis", sans-serif;
   /*font-size: 12px;*/
@@ -8,9 +7,7 @@ QGroupBox {
   border: 1px solid #254342;
   border-radius: 4px;
   margin-top: 10px;
-  font-weight: bold; }
-
-QGroupBox {
+  font-weight: bold;
   background-color: #a4d6d9; }
 
 QStatusBar {
@@ -96,7 +93,8 @@ QLineEdit {
   border: 1px solid #29394a;
   border-radius: 4px;
   padding: 0 8px;
-  color: #333333; }
+  color: #333333;
+  background-color: white; }
 
 QLineEdit:disabled {
   color: #333333;
@@ -104,7 +102,6 @@ QLineEdit:disabled {
 
 QTreeView {
   background-color: #7983b1;
-  alternate-background-color: #a3b1ed;
   color: white;
   font-weight: bold;
   font-family: "Roboto", sans-serif;

--- a/freemocap/gui/qt/style_sheet/qt_style_sheet.css
+++ b/freemocap/gui/qt/style_sheet/qt_style_sheet.css
@@ -85,6 +85,8 @@ WelcomeScreenButton[recommended_next=true] {
 QLabel {
   font-size: 14px;
   color: #333333; }
+  QTreeView QLabel {
+    color: black; }
 
 QLabel:disabled {
   color: #a4d6d9; }

--- a/freemocap/gui/qt/style_sheet/qt_style_sheet.css
+++ b/freemocap/gui/qt/style_sheet/qt_style_sheet.css
@@ -98,11 +98,11 @@ QLineEdit {
 
 QLineEdit:disabled {
   color: #333333;
-  background-color: #29394a; }
+  background-color: #687e90; }
 
 QTreeView {
   background-color: #7983b1;
-  color: white;
+  color: black;
   font-weight: bold;
   font-family: "Roboto", sans-serif;
   font-size: 12px; }

--- a/freemocap/gui/qt/style_sheet/qt_style_sheet.scss
+++ b/freemocap/gui/qt/style_sheet/qt_style_sheet.scss
@@ -11,7 +11,6 @@ $tree-primary: #7983b1;
 $tree-secondary: #a3b1ed;
 $plain-white: white;
 
-
 * {
     font-family: "Dosis", sans-serif;
     /*font-size: 12px;*/
@@ -23,13 +22,8 @@ QGroupBox {
     border-radius: 4px;
     margin-top: 10px;
     font-weight: bold;
-}
-QGroupBox{
     background-color: $skelly-bone-blue;
 }
-//QGroupBox[calibration_videos_radio_button_checked=true] {
-//    background-color: $laser-red;
-//}
 
 QStatusBar {
     color: $freemocap-green;
@@ -135,7 +129,7 @@ QLineEdit {
     border-radius: 4px;
     padding: 0 8px;
     color: $dark-charcoal;
-
+    background-color: $plain-white;
 }
 QLineEdit:disabled {
     color: $dark-charcoal;
@@ -144,7 +138,6 @@ QLineEdit:disabled {
 
 QTreeView {
     background-color: $tree-primary;
-    alternate-background-color: $tree-secondary;
     color: $plain-white;
     font-weight: bold;
     font-family: "Roboto", sans-serif;
@@ -169,3 +162,5 @@ LogViewWidget {
     font-size: 12px;
     padding: 8px;
 }
+
+

--- a/freemocap/gui/qt/style_sheet/qt_style_sheet.scss
+++ b/freemocap/gui/qt/style_sheet/qt_style_sheet.scss
@@ -115,6 +115,10 @@ WelcomeScreenButton[recommended_next = true] {
 QLabel {
     font-size: 14px;
     color: $dark-charcoal;
+
+    QTreeView & {
+        color: $plain-black;
+  }
 }
 
 QLabel:disabled {

--- a/freemocap/gui/qt/style_sheet/qt_style_sheet.scss
+++ b/freemocap/gui/qt/style_sheet/qt_style_sheet.scss
@@ -10,6 +10,7 @@ $disabled-button-blue: #687e90;
 $tree-primary: #7983b1;
 $tree-secondary: #a3b1ed;
 $plain-white: white;
+$plain-black: black;
 
 * {
     font-family: "Dosis", sans-serif;
@@ -70,7 +71,6 @@ QPushButton {
     color: $plain-white;
 }
 
-
 QPushButton:disabled {
     background-color: $tree-primary;
     border: 1px solid $tree-primary;
@@ -98,7 +98,6 @@ QPushButton#stop_recording_button:enabled {
     border: 3px solid $laser-red;
 }
 
-
 WelcomeScreenButton {
     border: 2px solid $dark-charcoal;
     background-color: $freemocap-green;
@@ -108,12 +107,10 @@ WelcomeScreenButton {
     padding: 10px;
 }
 
-
 WelcomeScreenButton[recommended_next = true] {
     background-color: $laser-red;
     color: $plain-white;
 }
-
 
 QLabel {
     font-size: 14px;
@@ -133,12 +130,12 @@ QLineEdit {
 }
 QLineEdit:disabled {
     color: $dark-charcoal;
-    background-color: $button-blue;
+    background-color: $disabled-button-blue;
 }
 
 QTreeView {
     background-color: $tree-primary;
-    color: $plain-white;
+    color: $plain-black;
     font-weight: bold;
     font-family: "Roboto", sans-serif;
     font-size: 12px;

--- a/freemocap/gui/qt/widgets/camera_controller_group_box.py
+++ b/freemocap/gui/qt/widgets/camera_controller_group_box.py
@@ -70,7 +70,7 @@ class CameraControllerGroupBox(QGroupBox):
 
         vbox.addLayout(hbox)
 
-        lag_note_label = QLabel("NOTE: Use fewer cameras or decrease resolution if you are experiecing lag")
+        lag_note_label = QLabel("NOTE: Use fewer cameras or decrease resolution if you are experiencing lag")
         vbox.addWidget(lag_note_label)
 
         return vbox

--- a/freemocap/gui/qt/widgets/camera_controller_group_box.py
+++ b/freemocap/gui/qt/widgets/camera_controller_group_box.py
@@ -50,6 +50,8 @@ class CameraControllerGroupBox(QGroupBox):
         self._layout.addWidget(self._skellycam_controller)
 
     def _create_videos_will_save_to_layout(self):
+        vbox = QVBoxLayout()
+
         hbox = QHBoxLayout()
         self._recording_string_tag_line_edit = QLineEdit(parent=self)
         self._recording_string_tag_line_edit.setPlaceholderText("(Optional)")
@@ -65,7 +67,13 @@ class CameraControllerGroupBox(QGroupBox):
         self._recording_path_label = QLabel(f"{self.get_new_recording_path()}")
         self._recording_path_label.setStyleSheet("font-family: monospace; font-size: 10px;")
         hbox.addWidget(self._recording_path_label)
-        return hbox
+
+        vbox.addLayout(hbox)
+
+        lag_note_label = QLabel("NOTE: Use fewer cameras or decrease resolution if you are experiecing lag")
+        vbox.addWidget(lag_note_label)
+
+        return vbox
 
     def _create_mocap_recording_option_layout(self):
         hbox = QHBoxLayout()

--- a/freemocap/gui/qt/widgets/camera_controller_group_box.py
+++ b/freemocap/gui/qt/widgets/camera_controller_group_box.py
@@ -70,7 +70,7 @@ class CameraControllerGroupBox(QGroupBox):
 
         vbox.addLayout(hbox)
 
-        lag_note_label = QLabel("NOTE: Use fewer cameras or decrease resolution if you are experiencing lag")
+        lag_note_label = QLabel("NOTE: If you experience lag in your camera views, decrease the resolution and/or use fewer cameras.\nWe are working on a fix which should be done 'soon' (written: 2023-04-05)")
         vbox.addWidget(lag_note_label)
 
         return vbox

--- a/freemocap/gui/qt/widgets/home_widget.py
+++ b/freemocap/gui/qt/widgets/home_widget.py
@@ -74,7 +74,7 @@ class HomeWidget(QWidget):
         self._send_pings_checkbox.setChecked(True)
         self._layout.addWidget(self._send_pings_checkbox, alignment=Qt.AlignmentFlag.AlignCenter)
 
-        privacy_policy_link_string = '<a href="https://freemocap.readthedocs.io/en/latest/privacy_policy/" style="color: white;">Click here to view our privacy policy</a>'
+        privacy_policy_link_string = '<a href="https://freemocap.readthedocs.io/en/latest/privacy_policy/" style="color: #333333;">Click here to view our privacy policy</a>'
         self._privacy_policy_link = QLabel(privacy_policy_link_string)
         self._privacy_policy_link.setOpenExternalLinks(True)
         self._layout.addWidget(self._privacy_policy_link, alignment=Qt.AlignmentFlag.AlignCenter)

--- a/freemocap/gui/qt/widgets/home_widget.py
+++ b/freemocap/gui/qt/widgets/home_widget.py
@@ -69,10 +69,15 @@ class HomeWidget(QWidget):
 
         self._layout.addStretch(1)
 
-        send_pings_string = "Send ping to devs to let us know when you make a new session (being able to show that people are using this thing will help us get funding for this project :D )"
+        send_pings_string = "Send anonymous usage information"
         self._send_pings_checkbox = QCheckBox(send_pings_string)
         self._send_pings_checkbox.setChecked(True)
-        self._layout.addWidget(self._send_pings_checkbox)
+        self._layout.addWidget(self._send_pings_checkbox, alignment=Qt.AlignmentFlag.AlignCenter)
+
+        privacy_policy_link_string = '<a href="https://freemocap.readthedocs.io/en/latest/privacy_policy/" style="color: white;">Click here to view our privacy policy</a>'
+        self._privacy_policy_link = QLabel(privacy_policy_link_string)
+        self._privacy_policy_link.setOpenExternalLinks(True)
+        self._layout.addWidget(self._privacy_policy_link, alignment=Qt.AlignmentFlag.AlignCenter)
 
         self.style().polish(self)
 


### PR DESCRIPTION
This pull request solves a number of the major color contrast issues in the GUI, although not all of them.

First, it fixes the major mac darkmode problem by setting a white background on all of the QLineEdit objects, turning this: 
<img width="860" alt="Screen Shot 2023-04-04 at 12 50 28 PM" src="https://user-images.githubusercontent.com/24758117/229927428-15d31afa-795b-4219-806d-d0abbfb9120f.png">
into this:
<img width="855" alt="Screen Shot 2023-04-04 at 3 32 10 PM" src="https://user-images.githubusercontent.com/24758117/229927474-993d5b0d-900c-474e-9801-5906d39bf3ca.png">

Second, it increases the color contrast of certain text, like the parameter tree text is now dark instead of white:
<img width="467" alt="Screen Shot 2023-04-04 at 3 33 54 PM" src="https://user-images.githubusercontent.com/24758117/229927760-3d394624-f61e-4fc6-a9ae-294ffb57d0b1.png">
And the text for the link to the privacy policy is now dark instead of white:
<img width="504" alt="Screen Shot 2023-04-04 at 3 34 29 PM" src="https://user-images.githubusercontent.com/24758117/229927878-adb3979c-2773-47a4-b6b9-5ec83ede84a0.png">

The only remaining issues are the user selections in the parameter tree that are still displaying dark on a mac in darkmode. They are only dark when they are selected (you can see them just fine when not selected). I can't figure out how to fix them in the css. Examples of what I'm talking about:

<img width="488" alt="Screen Shot 2023-04-04 at 3 03 46 PM" src="https://user-images.githubusercontent.com/24758117/229929035-aad464e8-464f-448b-9929-2a4e0b31ed79.png">
<img width="438" alt="Screen Shot 2023-04-04 at 3 03 58 PM" src="https://user-images.githubusercontent.com/24758117/229929048-bed3891e-7c7a-4f79-b400-c60beb383ab0.png">
