### PR TITLE
Auto find blender path on mac

### DIFF
--- a/freemocap/core_processes/export_data/blender_stuff/get_best_guess_of_blender_path.py
+++ b/freemocap/core_processes/export_data/blender_stuff/get_best_guess_of_blender_path.py
@@ -39,7 +39,7 @@ def get_best_guess_of_blender_path():
 
         blender_app_path = Path("/Applications/Blender.app")
         
-        if not blender_app_path.is_file():
+        if blender_app_path.exists():
             logger.info(f"Mac machine detected - guessing that `blender` is installed at: {str(blender_app_path)}")
 
             blender_exe_path = blender_app_path / "Contents/MacOS/Blender"

--- a/freemocap/core_processes/export_data/blender_stuff/get_best_guess_of_blender_path.py
+++ b/freemocap/core_processes/export_data/blender_stuff/get_best_guess_of_blender_path.py
@@ -35,6 +35,21 @@ def get_best_guess_of_blender_path():
             )
             return None
 
+    if platform.system() == "Darwin":
+
+        blender_app_path = Path("/Applications/Blender.app")
+        
+        if not blender_app_path.is_file():
+            logger.info(f"Mac machine detected - guessing that `blender` is installed at: {str(blender_app_path)}")
+
+            blender_exe_path = blender_app_path / "Contents/MacOS/Blender"
+            return str(blender_exe_path)
+        else:
+            logger.warning(
+                f"Could not find `blender.exe` in the applications folder. Please located it manually (or install Blender, if it isn't installed)."
+            )
+            return None
+
     else:
-        logger.info(f"Non-Windows machine detected - TODO - Test how this works on Mac/Linux")
+        logger.info(f"Non-Windows/Mac machine detected - TODO - Test how this works on Linux")
         return None

--- a/freemocap/core_processes/export_data/blender_stuff/get_best_guess_of_blender_path.py
+++ b/freemocap/core_processes/export_data/blender_stuff/get_best_guess_of_blender_path.py
@@ -46,7 +46,7 @@ def get_best_guess_of_blender_path():
             return str(blender_exe_path)
         else:
             logger.warning(
-                f"Could not find `blender.exe` in the applications folder. Please located it manually (or install Blender, if it isn't installed)."
+                f"Could not find Blender executable in the applications folder. Please located it manually (or install Blender, if it isn't installed)."
             )
             return None
 

--- a/freemocap/core_processes/post_process_skeleton_data/gap_fill_filter_and_origin_align_skeleton_data.py
+++ b/freemocap/core_processes/post_process_skeleton_data/gap_fill_filter_and_origin_align_skeleton_data.py
@@ -78,10 +78,10 @@ def fill_gaps_in_freemocap_data(inputData_frame_marker_xyz: np.ndarray) -> np.nd
             df.fillna(method="bfill", axis=0, inplace=True)
             df.fillna(method="ffill", axis=0, inplace=True)
 
-            if np.any(np.isnan(df.to_numpy())):
-                raise ValueError("Nans still present after interpolation")
-            if np.any(np.isinf(df.to_numpy())):
-                raise ValueError("Infs still present after interpolation")
+            # if np.any(np.isnan(df.to_numpy())):
+            #     raise ValueError("Nans still present after interpolation")
+            # if np.any(np.isinf(df.to_numpy())):
+            #     raise ValueError("Infs still present after interpolation")
 
             interpolatedData_frame_marker_xyz[:, marker_number, :] = df.to_numpy()
 
@@ -99,21 +99,25 @@ def butterworth_lowpass_zerolag_filter(data, cutoff, sampling_rate, order):
     return y
 
 
-def butterworth_filter_skeleton(skeleton_3d_data, cutoff, sampling_rate, order):
+def butterworth_filter_skeleton(skeleton_frame_marker_xyz, cutoff, sampling_rate, order):
     """Take in a 3d skeleton numpy array and calculate_center_of_mass a low pass butterworth filter on each marker in the data"""
 
-    butterworth_filtered_data = skeleton_3d_data.copy()
+    butterworth_filtered_data = skeleton_frame_marker_xyz.copy()
 
     for marker_number in range(NUMBER_OF_MEDIAPIPE_BODY_MARKERS):
-        for dimension in range(3):
+        trajectory_xyz = skeleton_frame_marker_xyz[:, marker_number, :]
+        if np.any(np.isnan(trajectory_xyz)):
+            logger.warning(f"Trajectory number {marker_number} has nans, skipping butterworth filter")
+            continue
+        for dimension in range(trajectory_xyz.shape[1]):
             butterworth_filtered_data[:, marker_number, dimension] = butterworth_lowpass_zerolag_filter(
-                skeleton_3d_data[:, marker_number, dimension],
+                trajectory_xyz[:,dimension],
                 cutoff,
                 sampling_rate,
                 order,
             )
 
-    assert skeleton_3d_data.shape == butterworth_filtered_data.shape
+    assert skeleton_frame_marker_xyz.shape == butterworth_filtered_data.shape
 
     return butterworth_filtered_data
 


### PR DESCRIPTION
This PR fixes the `get_best_guess_of_blender_path` function to find the blender path automatically on Mac systems. This was a TODO item in the code, and builds on #345 which enabled manual finding of the blender path on Macs. Because all applications are supposed to be stored in the application folder, the logic is fairly simple.

Screenshot showing Blender path autofilled on Mac.
<img width="512" alt="Blender path auto filled on Mac" src="https://user-images.githubusercontent.com/24758117/231816243-d9a45c75-3584-4de4-8a71-b754b0de5a65.png">
