### PR TITLE
disable repojection error filter (for now

### DIFF
--- a/freemocap/core_processes/capture_volume_calibration/triangulate_3d_data.py
+++ b/freemocap/core_processes/capture_volume_calibration/triangulate_3d_data.py
@@ -32,6 +32,10 @@ def remove_3d_data_with_high_reprojection_error(
     data3d_numFrames_numTrackedPoints_XYZ: np.ndarray,
     data3d_numFrames_numTrackedPoints_reprojectionError: np.ndarray,
 ):
+
+    return data3d_numFrames_numTrackedPoints_XYZ
+    # TODO - Fix this function (it was causing overfiltering when combined with the anipose calibration confidence thresholding)
+
     logger.info("Removing 3D data with high reprojection error")
     mean_reprojection_error_per_frame = np.nanmean(
         data3d_numFrames_numTrackedPoints_reprojectionError,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     "aniposelib",
     "libsass",
 ]
-requires-python = ">=3.8, <3.11"
+requires-python = ">=3.8"
 
 dynamic = ["version", "description"]
 


### PR DESCRIPTION
the combo of reprojection  and mediapipe confidence thresholding was leading to over-filtering, so I'm disabling this one for now