### PR TITLE
Headless Calibration

### DIFF
--- a/experimental/batch_process/headless_calibration.py
+++ b/experimental/batch_process/headless_calibration.py
@@ -27,7 +27,7 @@ def headless_calibration(
 
 if __name__ == "__main__":
     path_to_folder_of_calibration_videos = Path(
-        "/Users/philipqueen/Documents/Humon Research Lab/FreeMocap_Data/session/recording/4stepsequence_session1_10_5_22/synchronized_videos"
+        "/PATH/TO/CALIBRATION/VIDEOS"
     )
     charuco_square_size = 110  # size of a black square on your charuco board in mm
 

--- a/experimental/batch_process/headless_calibration.py
+++ b/experimental/batch_process/headless_calibration.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+from typing import Union
+
+from freemocap.core_processes.capture_volume_calibration.anipose_camera_calibration.anipose_camera_calibrator import (
+    AniposeCameraCalibrator,
+)
+from freemocap.core_processes.capture_volume_calibration.charuco_stuff.charuco_board_definition import (
+    CharucoBoardDefinition,
+)
+
+
+def headless_calibration(
+    path_to_folder_of_calibration_videos: Path,
+    charuco_board_object=CharucoBoardDefinition,
+    charuco_square_size: Union[int, float] = 39,
+    pin_camera_0_to_origin: bool = True,
+):
+    anipose_camera_calibrator = AniposeCameraCalibrator(
+        charuco_board_object=charuco_board_object,
+        charuco_square_size=charuco_square_size,
+        calibration_videos_folder_path=path_to_folder_of_calibration_videos,
+        progress_callback=lambda *args, **kwargs: None, # the empty callable is needed, otherwise calibration will cause an error
+    )
+
+    anipose_camera_calibrator.calibrate_camera_capture_volume(pin_camera_0_to_origin=pin_camera_0_to_origin)
+
+
+if __name__ == "__main__":
+    path_to_folder_of_calibration_videos = Path(
+        "/Users/philipqueen/Documents/Humon Research Lab/FreeMocap_Data/session/recording/4stepsequence_session1_10_5_22/synchronized_videos"
+    )
+    charuco_square_size = 110  # size of a black square on your charuco board in mm
+
+    headless_calibration(
+        path_to_folder_of_calibration_videos=path_to_folder_of_calibration_videos,
+        charuco_square_size=charuco_square_size,
+    )

--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
@@ -15,6 +15,7 @@ from freemocap.system.paths_and_files_names import (
     get_calibrations_folder_path,
     get_last_successful_calibration_toml_path, create_camera_calibration_file_name,
 )
+from freemocap.utilities.get_video_paths import get_video_paths
 
 logger = logging.getLogger(__name__)
 
@@ -44,9 +45,7 @@ class AniposeCameraCalibrator:
     def _get_video_paths(
         self,
     ):
-        self._list_of_video_paths = [
-            this_video_path for this_video_path in Path(self._calibration_videos_folder_path).glob("*.mp4".lower())
-        ]
+        self._list_of_video_paths = get_video_paths(path_to_video_folder=Path(self._calibration_videos_folder_path))
 
     def _initialize_anipose_objects(self):
         list_of_camera_names = [this_video_path.stem for this_video_path in self._list_of_video_paths]


### PR DESCRIPTION
This PR adds a script to the `experimental/batch_process` folder that creates a calibration file from a folder of videos. 

This will be useful for end to end testing. It also allows the creation of calibration files on a mac, as the zsh bus error in #334 is avoided when the process is run outside the gui. 