### PR TITLE
Automate end to end testing

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -23,7 +23,7 @@ jobs:
           pip install -e .
       - name: Replace Opencv with Headless
         run: |
-          pip uninstall opencv-contrib-python
+          pip uninstall -y opencv-contrib-python
           pip install opencv-contrib-python-headless
       - name: Run Tests with Pytest
         run: |

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -2,7 +2,7 @@ name: Freemocap Tests
 
 on:
   pull_request:
-    branches: [ jon/full-refactor ]
+    branches: [ main ]
     paths:
       - freemocap
 
@@ -26,7 +26,7 @@ jobs:
       - name: Run Tests with Pytest
         run: |
           pip install pytest
-          pytest freemocap/tests/test_test.py
+          pytest freemocap/tests
       - name: Upload pytest test results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -3,6 +3,8 @@ name: Freemocap Tests
 on:
   pull_request:
     branches: [ main ]
+    paths: 
+      - 'freemocap/**'
 
 jobs:
   build:

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -25,10 +25,3 @@ jobs:
         run: |
           pip install pytest
           pytest freemocap/tests
-      - name: Upload pytest test results
-        uses: actions/upload-artifact@v3
-        with:
-          name: pytest-results-3.9
-          path: junit/test-results-3.9.xml
-        # Use always() to always calculate_center_of_mass this step to publish test results when there are test failures
-        if: ${{ always() }}

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -e .
       - name: Run Tests with Pytest
         run: |
           pip install pytest

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -2,7 +2,7 @@ name: Freemocap Tests
 
 on:
   pull_request:
-    branches: [ main, philip/automate-end-to-end-testing ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -2,7 +2,7 @@ name: Freemocap Tests
 
 on:
   pull_request:
-    branches: [ main, philip/automate-end-to-end-testing ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -21,6 +21,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
+      - name: Replace Opencv with Headless
+        run: |
+          pip uninstall opencv-contrib-python
+          pip install opencv-contrib-python-headless
       - name: Run Tests with Pytest
         run: |
           pip install pytest

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -2,7 +2,7 @@ name: Freemocap Tests
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, philip/automate-end-to-end-testing ]
     paths:
       - freemocap
 

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -2,7 +2,7 @@ name: Freemocap Tests
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, philip/automate-end-to-end-testing ]
 
 jobs:
   build:

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -21,10 +21,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-      - name: Replace Opencv with Headless
+      - name: Install libegl1
         run: |
-          pip uninstall -y opencv-contrib-python
-          pip install opencv-contrib-python-headless
+          sudo apt-get update
+          sudo apt-get install libegl1-mesa
       - name: Run Tests with Pytest
         run: |
           pip install pytest

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -3,8 +3,6 @@ name: Freemocap Tests
 on:
   pull_request:
     branches: [ main, philip/automate-end-to-end-testing ]
-    paths:
-      - freemocap
 
 jobs:
   build:


### PR DESCRIPTION
This would close #389 by automating the newly added end to end testing. 

Right now, it is set to run whenever a PR is made to main that touches the `freemocap` folder. If that runs the tests too often and eats into our allotted github runner time we can think of a better way to determine when to run the tests.