### PR TITLE
Update latest rc version in pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ https://user-images.githubusercontent.com/15314521/192062522-2a8d9305-f181-4869-
 
 1. Install software via [pip](https://pypi.org/project/freemocap/1.0.0rc0/):
 ```
-pip install freemocap~=1.0.0rc0
+pip install freemocap~=1.0.12rc0
 ```
 
 2. Launch the GUI by entering the command:


### PR DESCRIPTION
Right now instructions in the readme say to download V1.0.0rc, but we've made a lot of fixes since then, so this points new users to the best functioning version