### PR TITLE
Patch: papermill in headless processing

### DIFF
--- a/freemocap/export_data/generate_jupyter_notebook/generate_jupyter_notebook.py
+++ b/freemocap/export_data/generate_jupyter_notebook/generate_jupyter_notebook.py
@@ -16,7 +16,7 @@ def generate_jupyter_notebook(path_to_recording: Union[str, Path]):
     success =  pm.execute_notebook(
         input_path=path_to_template_notebook,
         output_path=path_to_output_notebook,
-        parameters=dict(path_to_recording=path_to_recording)
+        parameters=dict(path_to_recording=str(path_to_recording))
     )
 
 


### PR DESCRIPTION
Fixes #409 

Papermill apparently needs the dictionary value to be a string rather than a PosixPath object. Making this change allowed me to properly create a jupyter notebook while headless processing both multi-camera and single camera recordings that had previously failed. The notebooks run properly without errors.