### PR TITLE
HOT FIX: fix JSON not found error

### DIFF
--- a/freemocap/gui/qt/workers/process_motion_capture_data_thread_worker.py
+++ b/freemocap/gui/qt/workers/process_motion_capture_data_thread_worker.py
@@ -1,5 +1,6 @@
 import logging
 import multiprocessing
+from pathlib import Path
 
 from PyQt6.QtCore import pyqtSignal, QThread
 
@@ -33,7 +34,8 @@ class ProcessMotionCaptureDataThreadWorker(QThread):
         self._kill_event.clear()
 
         recording_info_dict = self._session_processing_parameters.dict(exclude={'recording_info_model'})
-
+        Path(self._session_processing_parameters.recording_info_model.output_data_folder_path).mkdir(parents=True, exist_ok=True)
+        
         save_dictionary_to_json(
             save_path=self._session_processing_parameters.recording_info_model.output_data_folder_path,
             file_name=RECORDING_PARAMETER_DICT_JSON_FILE_NAME,


### PR DESCRIPTION
This causes an error by trying to save a dictionary to a path that doesn't exist yet. It was missed because it doesn't show up in the headless processing code for testing, and all the devs already had a json there to compare to