### PR TITLE
Fix Pydantic Errors

### DIFF
--- a/freemocap/core_processes/detecting_things_in_2d_images/mediapipe_stuff/mediapipe_skeleton_detector.py
+++ b/freemocap/core_processes/detecting_things_in_2d_images/mediapipe_stuff/mediapipe_skeleton_detector.py
@@ -74,7 +74,7 @@ class MediaPipeSkeletonDetector:
         logger.info(f"Running `mediapipe` skeleton detection on video: {str(synchronized_video_file_path)}")
 
         holistic_tracker = mp_holistic.Holistic(
-            mediapipe_model_complexity=mediapipe_parameters_model.mediapipe_model_complexity,
+            model_complexity=mediapipe_parameters_model.mediapipe_model_complexity,
             min_detection_confidence=mediapipe_parameters_model.min_detection_confidence,
             min_tracking_confidence=mediapipe_parameters_model.min_tracking_confidence,
         )

--- a/freemocap/core_processes/detecting_things_in_2d_images/mediapipe_stuff/mediapipe_skeleton_detector.py
+++ b/freemocap/core_processes/detecting_things_in_2d_images/mediapipe_stuff/mediapipe_skeleton_detector.py
@@ -74,7 +74,7 @@ class MediaPipeSkeletonDetector:
         logger.info(f"Running `mediapipe` skeleton detection on video: {str(synchronized_video_file_path)}")
 
         holistic_tracker = mp_holistic.Holistic(
-            model_complexity=mediapipe_parameters_model.model_complexity,
+            mediapipe_model_complexity=mediapipe_parameters_model.mediapipe_model_complexity,
             min_detection_confidence=mediapipe_parameters_model.min_detection_confidence,
             min_tracking_confidence=mediapipe_parameters_model.min_tracking_confidence,
         )

--- a/freemocap/data_layer/recording_models/post_processing_parameter_models.py
+++ b/freemocap/data_layer/recording_models/post_processing_parameter_models.py
@@ -28,9 +28,10 @@ class ButterworthFilterParametersModel(BaseModel):
     cutoff_frequency: float = 7
     order: int = 4
 
+
 class PostProcessingParametersModel(BaseModel):
     framerate: float = 30.0
-    butterworth_filter_parameters = ButterworthFilterParametersModel()
+    butterworth_filter_parameters: ButterworthFilterParametersModel = ButterworthFilterParametersModel()
     max_gap_to_fill: int = 10
     skip_butterworth_filter: bool = False
 

--- a/freemocap/data_layer/recording_models/post_processing_parameter_models.py
+++ b/freemocap/data_layer/recording_models/post_processing_parameter_models.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class MediapipeParametersModel(BaseModel):
-    model_complexity: int = 2
+    mediapipe_model_complexity: int = 2
     min_detection_confidence: float = 0.5
     min_tracking_confidence: float = 0.5
     static_image_mode: bool = False

--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
@@ -24,7 +24,7 @@ MINIUMUM_TRACKING_CONFIDENCE = "Minimum Tracking Confidence"
 
 MINIMUM_DETECTION_CONFIDENCE = "Minimum Detection Confidence"
 
-MODEL_COMPLEXITY = "Model Complexity"
+MEDIAPIPE_MODEL_COMPLEXITY = "Model Complexity"
 
 MEDIAPIPE_TREE_NAME = "Mediapipe"
 
@@ -38,7 +38,7 @@ SKIP_BUTTERWORTH_FILTER_NAME = "Skip butterworth filter?"
 def create_mediapipe_parameter_group(
         parameter_model: MediapipeParametersModel = MediapipeParametersModel(),
 ) -> Parameter:
-    model_complexity_list = [
+    mediapipe_model_complexity_list = [
         "0 (Fastest/Least accurate)",
         "1 (Middle ground)",
         "2 (Slowest/Most accurate)",
@@ -48,12 +48,12 @@ def create_mediapipe_parameter_group(
         type="group",
         children=[
             dict(
-                name=MODEL_COMPLEXITY,
+                name=MEDIAPIPE_MODEL_COMPLEXITY,
                 type="list",
-                limits=model_complexity_list,
-                value=model_complexity_list[parameter_model.model_complexity],
+                limits=mediapipe_model_complexity_list,
+                value=mediapipe_model_complexity_list[parameter_model.mediapipe_model_complexity],
                 tip="Which Mediapipe model to use - higher complexity is slower but more accurate. "
-                    "Variable name in `mediapipe` code: `model_complexity`",
+                    "Variable name in `mediapipe` code: `mediapipe_model_complexity`",
             ),
             dict(
                 name=MINIMUM_DETECTION_CONFIDENCE,
@@ -148,11 +148,11 @@ def extract_parameter_model_from_parameter_tree(
 ) -> PostProcessingParameterModel:
     parameter_values_dictionary = extract_processing_parameter_model_from_tree(parameter_object=parameter_object)
 
-    model_complexity_integer = get_integer_from_model_complexity(parameter_values_dictionary[MODEL_COMPLEXITY])
+    mediapipe_model_complexity_integer = get_integer_from_mediapipe_model_complexity(parameter_values_dictionary[MEDIAPIPE_MODEL_COMPLEXITY])
 
     return PostProcessingParameterModel(
         mediapipe_parameters_model=MediapipeParametersModel(
-            model_complexity=model_complexity_integer,
+            mediapipe_model_complexity=mediapipe_model_complexity_integer,
             min_detection_confidence=parameter_values_dictionary[MINIMUM_DETECTION_CONFIDENCE],
             min_tracking_confidence=parameter_values_dictionary[MINIUMUM_TRACKING_CONFIDENCE],
             static_image_mode=parameter_values_dictionary[STATIC_IMAGE_MODE],
@@ -174,13 +174,13 @@ def extract_parameter_model_from_parameter_tree(
             )
         )
 
-def get_integer_from_model_complexity(model_complexity_value: str):
-    model_complexity_dictionary = {
+def get_integer_from_mediapipe_model_complexity(mediapipe_model_complexity_value: str):
+    mediapipe_model_complexity_dictionary = {
         "0 (Fastest/Least accurate)": 0,
         "1 (Middle ground)": 1,
         "2 (Slowest/Most accurate)": 2,
     }
-    return model_complexity_dictionary[model_complexity_value]
+    return mediapipe_model_complexity_dictionary[mediapipe_model_complexity_value]
 
 def extract_processing_parameter_model_from_tree(parameter_object, value_dictionary: dict=None):
     if value_dictionary is None:


### PR DESCRIPTION
This pull request fixes the following two errors I was getting after following the installation instructions and running `freemocap`:

```shell
NameError: Field "model_complexity" has conflict with protected namespace "model_"
``` 
```shell
pydantic.errors.PydanticUserError: A non-annotated attribute was detected: `butterworth_filter_parameters = ButterworthFilterParametersModel(sampling_rate=30, cutoff_frequency=7, order=4)`. All model fields require a type annotation; if `butterworth_filter_parameters` is not meant to be a field, you may be able to resolve this error by annotating it as a `ClassVar` or updating `model_config['ignored_types']`.
``` 

The NameError fix coming from a recent issue in the Pydantic repository: [https://github.com/pydantic/pydantic/issues/6322](https://github.com/pydantic/pydantic/issues/6322)

The second error is fixed by simply adding a type annotation to the `butterworth_filter_parameters` field on the `PostProcessingParametersModel` class.

The GUI now starts up properly for me.

My system info:
OS: Linux Mint 20.1
Kernel: Linux Kernel 5.4.0-153-generic
Processor: AMD Ryzen 7 3800X
Memory: 64gb

Full error stack traces:
```shell
Traceback (most recent call last):
  File "/home/robot/anaconda3/envs/freemocap-env/bin/freemocap", line 5, in <module>
    from freemocap.__main__ import main
  File "/home/robot/dev/freemocap/freemocap/__main__.py", line 12, in <module>
    from freemocap.gui.qt.freemocap_main import qt_gui_main
  File "/home/robot/dev/freemocap/freemocap/gui/qt/freemocap_main.py", line 9, in <module>
    from freemocap.gui.qt.main_window.freemocap_main_window import FreemocapMainWindow, EXIT_CODE_REBOOT
  File "/home/robot/dev/freemocap/freemocap/gui/qt/main_window/freemocap_main_window.py", line 40, in <module>
    from freemocap.gui.qt.widgets.control_panel.control_panel_dock_widget import (
  File "/home/robot/dev/freemocap/freemocap/gui/qt/widgets/control_panel/control_panel_dock_widget.py", line 10, in <module>
    from freemocap.gui.qt.widgets.control_panel.process_mocap_data_panel.process_motion_capture_data_panel import (
  File "/home/robot/dev/freemocap/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/process_motion_capture_data_panel.py", line 12, in <module>
    from freemocap.gui.qt.widgets.control_panel.process_mocap_data_panel.parameter_groups.create_parameter_groups import (
  File "/home/robot/dev/freemocap/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py", line 3, in <module>
    from freemocap.parameter_info_models.recording_processing_parameter_models import MediapipeParametersModel, \
  File "/home/robot/dev/freemocap/freemocap/parameter_info_models/recording_processing_parameter_models.py", line 12, in <module>
    class MediapipeParametersModel(BaseModel):
  File "/home/robot/anaconda3/envs/freemocap-env/lib/python3.10/site-packages/pydantic/_internal/_model_construction.py", line 171, in __new__
    set_model_fields(cls, bases, config_wrapper, types_namespace)
  File "/home/robot/anaconda3/envs/freemocap-env/lib/python3.10/site-packages/pydantic/_internal/_model_construction.py", line 361, in set_model_fields
    fields, class_vars = collect_model_fields(cls, bases, config_wrapper, types_namespace, typevars_map=typevars_map)
  File "/home/robot/anaconda3/envs/freemocap-env/lib/python3.10/site-packages/pydantic/_internal/_fields.py", line 112, in collect_model_fields
    raise NameError(f'Field "{ann_name}" has conflict with protected namespace "{protected_namespace}"')
NameError: Field "model_complexity" has conflict with protected namespace "model_"
``` 
```shell
Traceback (most recent call last):
  File "/home/robot/anaconda3/envs/freemocap-env/bin/freemocap", line 5, in <module>
    from freemocap.__main__ import main
  File "/home/robot/dev/freemocap/freemocap/__main__.py", line 12, in <module>
    from freemocap.gui.qt.freemocap_main import qt_gui_main
  File "/home/robot/dev/freemocap/freemocap/gui/qt/freemocap_main.py", line 9, in <module>
    from freemocap.gui.qt.main_window.freemocap_main_window import FreemocapMainWindow, EXIT_CODE_REBOOT
  File "/home/robot/dev/freemocap/freemocap/gui/qt/main_window/freemocap_main_window.py", line 40, in <module>
    from freemocap.gui.qt.widgets.control_panel.control_panel_dock_widget import (
  File "/home/robot/dev/freemocap/freemocap/gui/qt/widgets/control_panel/control_panel_dock_widget.py", line 10, in <module>
    from freemocap.gui.qt.widgets.control_panel.process_mocap_data_panel.process_motion_capture_data_panel import (
  File "/home/robot/dev/freemocap/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/process_motion_capture_data_panel.py", line 12, in <module>
    from freemocap.gui.qt.widgets.control_panel.process_mocap_data_panel.parameter_groups.create_parameter_groups import (
  File "/home/robot/dev/freemocap/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py", line 3, in <module>
    from freemocap.parameter_info_models.recording_processing_parameter_models import MediapipeParametersModel, \
  File "/home/robot/dev/freemocap/freemocap/parameter_info_models/recording_processing_parameter_models.py", line 33, in <module>
    class PostProcessingParametersModel(BaseModel):
  File "/home/robot/anaconda3/envs/freemocap-env/lib/python3.10/site-packages/pydantic/_internal/_model_construction.py", line 95, in __new__
    private_attributes = inspect_namespace(
  File "/home/robot/anaconda3/envs/freemocap-env/lib/python3.10/site-packages/pydantic/_internal/_model_construction.py", line 328, in inspect_namespace
    raise PydanticUserError(
pydantic.errors.PydanticUserError: A non-annotated attribute was detected: `butterworth_filter_parameters = ButterworthFilterParametersModel(sampling_rate=30, cutoff_frequency=7, order=4)`. All model fields require a type annotation; if `butterworth_filter_parameters` is not meant to be a field, you may be able to resolve this error by annotating it as a `ClassVar` or updating `model_config['ignored_types']`.
``` 