### PR TITLE
PATCH: Change freemocap_main back to main

### DIFF
--- a/freemocap/__init__.py
+++ b/freemocap/__init__.py
@@ -44,5 +44,5 @@ def RunMe(*args, **kwargs):
           "(NOTE  - this entry point will be removed eventually\n"
           "--------------------------------\n")
 
-    from freemocap.__main__ import freemocap_main
-    freemocap_main()
+    from freemocap.__main__ import main
+    main()

--- a/freemocap/__main__.py
+++ b/freemocap/__main__.py
@@ -13,7 +13,7 @@ except Exception as e:
     from freemocap.gui.qt.freemocap_main import qt_gui_main
 
 
-def freemocap_main():
+def main():
 
     # set up so you can change the taskbar icon - https://stackoverflow.com/a/74531530/14662833
     import ctypes
@@ -30,4 +30,4 @@ if __name__ == "__main__":
     freeze_support()
     print(f"Running `freemocap.__main__` from - {__file__}")
 
-    freemocap_main()
+    main()

--- a/src/gui/main/main.py
+++ b/src/gui/main/main.py
@@ -18,6 +18,6 @@ if __name__ == "__main__":
           "--------------------------------\n"
           "--------------------------------\n")
 
-    from freemocap.__main__ import freemocap_main
+    from freemocap.__main__ import main
 
-    freemocap_main()
+    main()


### PR DESCRIPTION
Running `freemocap` after a pip install is broken because the name of the function in `__main__.py` changed from `main` to `freemocap_main` without being changed in `pyproject.toml`. This patch changes the name back to main to keep our readme instructions working and consistent across versions.