### PR TITLE
unpin mediapipe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "skellycam",
     "skelly_viewer",
     "skellyforge",
-    "mediapipe==0.10.1",
+    "mediapipe",
     "opencv-contrib-python==4.6.0.66",
     "toml==0.10.2",
     "aniposelib==0.4.3",


### PR DESCRIPTION
pinning mediapipe was causing fail when installing to mac, so lets unpin for now