### PR TITLE
PATCH: thresholding error

### DIFF
--- a/freemocap/core_processes/capture_volume_calibration/triangulate_3d_data.py
+++ b/freemocap/core_processes/capture_volume_calibration/triangulate_3d_data.py
@@ -95,10 +95,10 @@ def triangulate_3d_data(
         )
         raise Exception
 
-    mediapipe_2d_data = threshold_by_confidence(
-        mediapipe_2d_data=mediapipe_2d_data,
-        mediapipe_confidence_cutoff_threshold=mediapipe_confidence_cutoff_threshold,
-    )
+    # mediapipe_2d_data = threshold_by_confidence(
+    #     mediapipe_2d_data=mediapipe_2d_data,
+    #     mediapipe_confidence_cutoff_threshold=mediapipe_confidence_cutoff_threshold,
+    # )
 
     # reshape data to collapse across 'frames' so it becomes [number_of_cameras,
     # number_of_2d_points(numFrames*numPoints), XY]


### PR DESCRIPTION
This comments out the thresholding function that is incorrectly thresholding across the X and Y spatial dimensions in the data. It would close #458, although we need to decide what we want to do about filtering as a long term solution.