### PR TITLE
PATCH: fix batch processing error

### DIFF
--- a/experimental/batch_process/batch_process.py
+++ b/experimental/batch_process/batch_process.py
@@ -62,6 +62,8 @@ def process_recording_without_gui(
 
     recording_info_dict = rec.dict(exclude={'recording_info_model'})
 
+    Path(rec.recording_info_model.output_data_folder_path).mkdir(parents=True, exist_ok=True)
+
     save_dictionary_to_json(
         save_path=rec.recording_info_model.output_data_folder_path,
         file_name=RECORDING_PARAMETERS_JSON_FILE_NAME,


### PR DESCRIPTION
When saving the recording parameters, you need to make sure the output data folder is created before trying to save a file there. We made this change everywhere else when we added that feature, but must have missed this. 

In the future, should we consider just creating the output data folder when we create the session folder? This would prevent having to duplicate this code across so many different places. Alternatively, we could have the save to json function create the output folder if it doesn't exist yet. Both are DRYer than this method.

For now though, this fixes #462 