### PR TITLE
By camera reprojection filtering

### DIFF
--- a/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
+++ b/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
@@ -123,13 +123,13 @@ def set_unincluded_data_to_nans(
     mediapipe_2d_data: np.ndarray,
     frames_with_reprojection_error: list,
     markers_with_reprojection_error: list,
-    cameras_to_remove: list[int],
+    cameras_to_remove: list[list[int]],
 ) -> np.ndarray:
     data_to_reproject = mediapipe_2d_data.copy()
     for camera, frame, marker in zip(
         cameras_to_remove, frames_with_reprojection_error, markers_with_reprojection_error
     ):
-        data_to_reproject[camera, frame, marker, :] = np.nan
+        data_to_reproject[camera[0], frame, marker, :] = np.nan
     return data_to_reproject
 
 

--- a/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
+++ b/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
@@ -38,10 +38,7 @@ def filter_by_reprojection_error(
     body2d_camera_frame_marker_xy = mediapipe_2d_data[:, :, :NUMBER_OF_MEDIAPIPE_BODY_MARKERS, :2]
     bodyReprojErr_camera_frame_marker = reprojection_error_camera_frame_marker[:, :, :NUMBER_OF_MEDIAPIPE_BODY_MARKERS]
 
-    if reprojection_error_confidence_threshold > 100:
-        reprojection_error_confidence_threshold = 100
-    if reprojection_error_confidence_threshold < 0:
-        reprojection_error_confidence_threshold = 0
+    reprojection_error_confidence_threshold = min(max(reprojection_error_confidence_threshold, 0), 100)
 
     reprojection_error_threshold = np.nanpercentile(
         bodyReprojErr_camera_frame_marker, reprojection_error_confidence_threshold
@@ -130,6 +127,16 @@ def get_unique_frame_marker_list(
 def get_camera_frame_marker_lists_to_reproject(
     reprojError_cam_frame_marker: np.ndarray, frame_marker_list: list, num_cameras_to_remove: int,
 ) -> Tuple[list, list, list]:
+    """
+    Generate the lists of cameras, frames, and markers to reproject based on the given input.
+    Find the cameras with the worst reprojection errors for the given frames and markers.
+    Args:
+        reprojError_cam_frame_marker (np.ndarray): The array containing the reprojection errors for each camera, frame, and marker.
+        frame_marker_list (list): The list of tuples containing the frame and marker indices.
+        num_cameras_to_remove (int): The number of cameras to remove.
+    Returns:
+        Tuple[list, list, list]: A tuple containing the lists of cameras to remove, frames to reproject, and markers to reproject.
+    """
     cameras_to_remove = []
     frames_to_reproject = []
     markers_to_reproject = []
@@ -137,7 +144,7 @@ def get_camera_frame_marker_lists_to_reproject(
         frames_to_reproject.append(frame)
         markers_to_reproject.append(marker)
         max_indices = reprojError_cam_frame_marker[:, frame, marker].argsort()[::-1][:num_cameras_to_remove]
-        cameras_to_remove.append(max_indices)
+        cameras_to_remove.append(list(max_indices))
     return (cameras_to_remove, frames_to_reproject, markers_to_reproject)
 
 

--- a/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
+++ b/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
@@ -20,9 +20,10 @@ def filter_by_reprojection_error(
     raw_skel3d_frame_marker_xyz: np.ndarray,
     anipose_calibration_object,
     use_triangulate_ransac: bool = False,
-    minimum_cameras_to_reproject: int = 2,
+    minimum_cameras_to_reproject: int = 3,
 ) -> Tuple[np.ndarray, np.ndarray]:
     total_cameras = mediapipe_2d_data.shape[0]
+    total_frame_marker_combos = raw_skel3d_frame_marker_xyz.shape[0] * raw_skel3d_frame_marker_xyz.shape[1]
     num_cameras_to_remove = 1
 
     if total_cameras <= minimum_cameras_to_reproject:
@@ -46,18 +47,18 @@ def filter_by_reprojection_error(
 
     indices_above_threshold = np.nonzero(bodyReprojErr_camera_frame_marker > reprojection_error_threshold)
 
-    unique_frame_marker_list = get_unique_frame_marker_list(indices_above_threshold=indices_above_threshold)
+    unique_frame_marker_list = _get_unique_frame_marker_list(indices_above_threshold=indices_above_threshold)
     logger.info(
-        f"number of frame/marker combos with reprojection error above threshold: {len(unique_frame_marker_list)}"
-    )
+        f"number of frame/marker combos with reprojection error above threshold: {len(unique_frame_marker_list)} ({len(unique_frame_marker_list)/total_frame_marker_combos * 100} percent of total)"
+    ) # TODO: add a percentage here
 
-    cameras_to_remove, frames_to_reproject, markers_to_reproject = get_camera_frame_marker_lists_to_reproject(
+    cameras_to_remove, frames_to_reproject, markers_to_reproject = _get_camera_frame_marker_lists_to_reproject(
         reprojError_cam_frame_marker=bodyReprojErr_camera_frame_marker,
         frame_marker_list=unique_frame_marker_list,
         num_cameras_to_remove=num_cameras_to_remove,
     )
 
-    data_to_reproject_camera_frame_marker_xy = set_unincluded_data_to_nans(
+    data_to_reproject_camera_frame_marker_xy = _set_unincluded_data_to_nans(
         mediapipe_2d_data=body2d_camera_frame_marker_xy,
         frames_with_reprojection_error=frames_to_reproject,
         markers_with_reprojection_error=markers_to_reproject,
@@ -78,20 +79,20 @@ def filter_by_reprojection_error(
 
         indices_above_threshold = np.nonzero(new_reprojError_cam_frame_marker > reprojection_error_threshold)
 
-        unique_frame_marker_list = get_unique_frame_marker_list(indices_above_threshold=indices_above_threshold)
+        unique_frame_marker_list = _get_unique_frame_marker_list(indices_above_threshold=indices_above_threshold)
         logger.info(
-            f"number of frame/marker combos with reprojection error above threshold after filtering: {len(unique_frame_marker_list)}"
+            f"number of frame/marker combos with reprojection error above threshold after filtering: {len(unique_frame_marker_list)} ({len(unique_frame_marker_list)/total_frame_marker_combos * 100} percent of total)"
         )
 
         num_cameras_to_remove += 1
 
-        cameras_to_remove, frames_to_reproject, markers_to_reproject = get_camera_frame_marker_lists_to_reproject(
+        cameras_to_remove, frames_to_reproject, markers_to_reproject = _get_camera_frame_marker_lists_to_reproject(
             reprojError_cam_frame_marker=new_reprojError_cam_frame_marker,
             frame_marker_list=unique_frame_marker_list,
             num_cameras_to_remove=num_cameras_to_remove,
         )
 
-        data_to_reproject_camera_frame_marker_xy = set_unincluded_data_to_nans(
+        data_to_reproject_camera_frame_marker_xy = _set_unincluded_data_to_nans(
             mediapipe_2d_data=data_to_reproject_camera_frame_marker_xy,
             frames_with_reprojection_error=frames_to_reproject,
             markers_with_reprojection_error=markers_to_reproject,
@@ -125,13 +126,13 @@ def filter_by_reprojection_error(
     )
 
 
-def get_unique_frame_marker_list(
+def _get_unique_frame_marker_list(
     indices_above_threshold: np.ndarray,
 ) -> list:
     return list(set(zip(indices_above_threshold[1], indices_above_threshold[2])))
 
 
-def get_camera_frame_marker_lists_to_reproject(
+def _get_camera_frame_marker_lists_to_reproject(
     reprojError_cam_frame_marker: np.ndarray,
     frame_marker_list: list,
     num_cameras_to_remove: int,
@@ -157,7 +158,7 @@ def get_camera_frame_marker_lists_to_reproject(
     return (cameras_to_remove, frames_to_reproject, markers_to_reproject)
 
 
-def set_unincluded_data_to_nans(
+def _set_unincluded_data_to_nans(
     mediapipe_2d_data: np.ndarray,
     frames_with_reprojection_error: list,
     markers_with_reprojection_error: list,

--- a/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
+++ b/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
@@ -1,0 +1,162 @@
+import logging
+from pathlib import Path
+from typing import Tuple, Union
+from matplotlib import pyplot as plt
+import numpy as np
+from freemocap.core_processes.capture_volume_calibration.triangulate_3d_data import triangulate_3d_data
+
+from freemocap.core_processes.detecting_things_in_2d_images.mediapipe_stuff.data_models.mediapipe_skeleton_names_and_connections import (
+    NUMBER_OF_MEDIAPIPE_BODY_MARKERS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def filter_by_reprojection_error(
+    reprojection_error_camera_frame_marker: np.ndarray,
+    reprojection_error_frame_marker: np.ndarray,
+    reprojection_error_confidence_threshold: float,
+    mediapipe_2d_data: np.ndarray,
+    raw_skel3d_frame_marker_xyz: np.ndarray,
+    anipose_calibration_object,
+    output_data_folder_path: Union[str, Path],
+    use_triangulate_ransac: bool = False,
+    minimum_cameras_to_reproject: int = 2,
+) -> Tuple[np.ndarray, np.ndarray]:
+    body2d_camera_frame_marker_xy = mediapipe_2d_data[:, :, :NUMBER_OF_MEDIAPIPE_BODY_MARKERS, :2]
+    bodyReprojErr_camera_frame_marker = reprojection_error_camera_frame_marker[:, :, :NUMBER_OF_MEDIAPIPE_BODY_MARKERS]
+
+    if reprojection_error_confidence_threshold > 100:
+        reprojection_error_confidence_threshold = 100
+    if reprojection_error_confidence_threshold < 0:
+        reprojection_error_confidence_threshold = 0
+
+    reprojection_error_threshold = np.nanpercentile(
+        bodyReprojErr_camera_frame_marker, reprojection_error_confidence_threshold
+    )
+
+    # create before plot for debugging
+    plot_reprojection_error(
+        reprojection_error_frame_marker=reprojection_error_frame_marker,
+        reprojection_error_threshold=reprojection_error_threshold,
+        output_folder_path=output_data_folder_path,
+        after_filtering=False,
+    )
+
+    indices_above_threshold = np.nonzero(bodyReprojErr_camera_frame_marker > reprojection_error_threshold)
+
+    frame_marker_set = set()
+    for frame, marker in zip(
+        indices_above_threshold[1], indices_above_threshold[2]
+    ):
+        frame_marker_set.add((frame, marker))
+
+    frame_marker_list = list(frame_marker_set)
+    logger.info(f"number of frame/marker combos with reprojection error above threshold: {len(frame_marker_list)}")
+
+    (cameras_to_remove, frames_to_reproject, markers_to_reproject) = get_camera_frame_marker_lists_to_reproject(
+        reprojError_cam_frame_marker=bodyReprojErr_camera_frame_marker,
+        frame_marker_list=frame_marker_list,
+    )
+
+    data_to_reproject_camera_frame_marker_xy = set_unincluded_data_to_nans(
+        mediapipe_2d_data=body2d_camera_frame_marker_xy,
+        frames_with_reprojection_error=frames_to_reproject,
+        markers_with_reprojection_error=markers_to_reproject,
+        cameras_to_remove=cameras_to_remove,
+    )
+
+    (
+        retriangulated_data_frame_marker_xyz,
+        new_reprojection_error_flat,
+        new_reprojError_cam_frame_marker,
+    ) = triangulate_3d_data(
+        anipose_calibration_object=anipose_calibration_object,
+        mediapipe_2d_data=data_to_reproject_camera_frame_marker_xy,
+        use_triangulate_ransac=use_triangulate_ransac,
+    )
+
+    plot_reprojection_error(
+        reprojection_error_frame_marker=new_reprojection_error_flat,
+        reprojection_error_threshold=reprojection_error_threshold,
+        output_folder_path=output_data_folder_path,
+        after_filtering=True,
+    )
+
+    # put retriangulated data back in place
+    filtered_skel3d_frame_marker_xyz = raw_skel3d_frame_marker_xyz.copy()
+    filtered_skel3d_frame_marker_xyz[:, :NUMBER_OF_MEDIAPIPE_BODY_MARKERS, :] = retriangulated_data_frame_marker_xyz
+
+    filtered_reprojection_error_frame_marker = reprojection_error_frame_marker.copy()
+    filtered_reprojection_error_frame_marker[:, :NUMBER_OF_MEDIAPIPE_BODY_MARKERS] = new_reprojection_error_flat
+
+    filtered_reprojection_error_camera_frame_marker = reprojection_error_camera_frame_marker.copy()
+    filtered_reprojection_error_camera_frame_marker[:, :, :NUMBER_OF_MEDIAPIPE_BODY_MARKERS] = new_reprojError_cam_frame_marker
+
+    return (
+        filtered_skel3d_frame_marker_xyz,
+        filtered_reprojection_error_frame_marker,
+        filtered_reprojection_error_camera_frame_marker,
+    )
+
+
+def get_camera_frame_marker_lists_to_reproject(
+    reprojError_cam_frame_marker: np.ndarray, frame_marker_list: list
+) -> Tuple[list, list, list]:
+    cameras_to_remove = []
+    frames_to_reproject = []
+    markers_to_reproject = []
+    for frame, marker in frame_marker_list:
+        frames_to_reproject.append(frame)
+        markers_to_reproject.append(marker)
+        max_index = reprojError_cam_frame_marker[:, frame, marker].argmax()
+        cameras_to_remove.append([max_index])
+    return (cameras_to_remove, frames_to_reproject, markers_to_reproject)
+
+
+def set_unincluded_data_to_nans(
+    mediapipe_2d_data: np.ndarray,
+    frames_with_reprojection_error: list,
+    markers_with_reprojection_error: list,
+    cameras_to_remove: list[int],
+) -> np.ndarray:
+    data_to_reproject = mediapipe_2d_data.copy()
+    for camera, frame, marker in zip(
+        cameras_to_remove, frames_with_reprojection_error, markers_with_reprojection_error
+    ):
+        data_to_reproject[camera, frame, marker, :] = np.nan
+    return data_to_reproject
+
+
+def plot_reprojection_error(
+    reprojection_error_frame_marker: np.ndarray,
+    reprojection_error_threshold: float,
+    output_folder_path: Union[str, Path],
+    after_filtering: bool = False,
+) -> None:
+    title = "Mean Reprojection Error Per Frame"
+    file_name = "debug_reprojection_error_filtering.png"
+    output_filepath = Path(output_folder_path) / file_name
+    mean_reprojection_error_per_frame = np.nanmean(
+        reprojection_error_frame_marker,
+        axis=1,
+    )
+    if after_filtering:
+        plt.plot(mean_reprojection_error_per_frame, color="orange", alpha=0.9, label="Data After Filtering")
+        plt.xlabel("Frame")
+        plt.ylabel("Mean Reprojection Error Across Markers (mm)")
+        plt.ylim(0, 2 * reprojection_error_threshold)
+        plt.hlines(
+            y=reprojection_error_threshold,
+            xmin=0,
+            xmax=len(mean_reprojection_error_per_frame),
+            color="red",
+            label="Cutoff Threshold",
+        )
+        plt.title(title)
+        plt.legend(loc="upper right")
+        logger.info(f"Saving debug plots to: {output_filepath}")
+        plt.savefig(output_filepath, dpi=300)
+    else:
+        plt.plot(mean_reprojection_error_per_frame, color="blue", label="Data Before Filtering")
+

--- a/freemocap/core_processes/capture_volume_calibration/reprojection_filtering.py
+++ b/freemocap/core_processes/capture_volume_calibration/reprojection_filtering.py
@@ -118,7 +118,7 @@ def filter_by_reprojection_error(
     filtered_reprojection_error_frame_marker = reprojection_error_frame_marker.copy()
     filtered_reprojection_error_frame_marker[:, :NUMBER_OF_MEDIAPIPE_BODY_MARKERS] = bodyReprojErr_frame_marker
 
-    return (filtered_skel3d_frame_marker_xyz, filtered_reprojection_error_frame_marker)
+    return (filtered_skel3d_frame_marker_xyz, filtered_reprojection_error_frame_marker, new_reprojError_cam_frame_marker)
 
 
 def find_frames_with_reprojection_error_above_limit(

--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
@@ -189,7 +189,6 @@ def process_recording_folder(
                     mediapipe_2d_data=mediapipe_image_data_numCams_numFrames_numTrackedPts_XYZ[:, :, :, :2],
                     raw_skel3d_frame_marker_xyz=raw_skel3d_frame_marker_xyz,
                     anipose_calibration_object=anipose_calibration_object,
-                    output_data_folder_path=rec.recording_info_model.raw_data_folder_path,
                     use_triangulate_ransac=rec.anipose_triangulate_3d_parameters_model.use_triangulate_ransac_method,
                 )
                 save_mediapipe_3d_data_to_npy(

--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
@@ -8,7 +8,10 @@ import pandas as pd
 from freemocap.core_processes.capture_volume_calibration.anipose_camera_calibration.get_anipose_calibration_object import (
     load_anipose_calibration_toml_from_path,
 )
-from freemocap.core_processes.capture_volume_calibration.by_camera_reprojection_filtering import filter_by_reprojection_error
+from freemocap.core_processes.capture_volume_calibration.by_camera_reprojection_filtering import (
+    filter_by_reprojection_error,
+    plot_reprojection_error,
+)
 from freemocap.core_processes.capture_volume_calibration.triangulate_3d_data import (
     triangulate_3d_data,
 )
@@ -181,7 +184,7 @@ def process_recording_folder(
                 (
                     reprojection_filtered_skel3d_frame_marker_xyz,
                     reprojection_filtered_skeleton_reprojection_error_fr_mar,
-                    reprojection_filtered_skeleton_reprojection_error_cam_fr_mar
+                    reprojection_filtered_skeleton_reprojection_error_cam_fr_mar,
                 ) = filter_by_reprojection_error(
                     reprojection_error_camera_frame_marker=skeleton_reprojection_error_cam_fr_mar,
                     reprojection_error_frame_marker=skeleton_reprojection_error_fr_mar,
@@ -198,6 +201,12 @@ def process_recording_folder(
                     data3d_numCams_numFrames_numTrackedPoints_reprojectionError=reprojection_filtered_skeleton_reprojection_error_cam_fr_mar,
                     path_to_folder_where_data_will_be_saved=rec.recording_info_model.raw_data_folder_path,
                     processing_level="reprojection_filtered",
+                )
+                plot_reprojection_error(
+                    raw_reprojection_error_frame_marker=skeleton_reprojection_error_fr_mar,
+                    filtered_reprojection_error_frame_marker=reprojection_filtered_skeleton_reprojection_error_fr_mar,
+                    reprojection_error_threshold=np.nanpercentile(skeleton_reprojection_error_cam_fr_mar, rec.anipose_triangulate_3d_parameters_model.reprojection_error_confidence_cutoff),
+                    output_folder_path=rec.recording_info_model.raw_data_folder_path,
                 )
 
     if kill_event is not None and kill_event.is_set():

--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
@@ -8,7 +8,7 @@ import pandas as pd
 from freemocap.core_processes.capture_volume_calibration.anipose_camera_calibration.get_anipose_calibration_object import (
     load_anipose_calibration_toml_from_path,
 )
-from freemocap.core_processes.capture_volume_calibration.reprojection_filtering import filter_by_reprojection_error
+from freemocap.core_processes.capture_volume_calibration.by_camera_reprojection_filtering import filter_by_reprojection_error
 from freemocap.core_processes.capture_volume_calibration.triangulate_3d_data import (
     triangulate_3d_data,
 )
@@ -181,7 +181,9 @@ def process_recording_folder(
                 (
                     reprojection_filtered_skel3d_frame_marker_xyz,
                     reprojection_filtered_skeleton_reprojection_error_fr_mar,
+                    reprojection_filtered_skeleton_reprojection_error_cam_fr_mar
                 ) = filter_by_reprojection_error(
+                    reprojection_error_camera_frame_marker=skeleton_reprojection_error_cam_fr_mar,
                     reprojection_error_frame_marker=skeleton_reprojection_error_fr_mar,
                     reprojection_error_confidence_threshold=rec.anipose_triangulate_3d_parameters_model.reprojection_error_confidence_cutoff,
                     mediapipe_2d_data=mediapipe_image_data_numCams_numFrames_numTrackedPts_XYZ[:, :, :, :2],
@@ -193,7 +195,7 @@ def process_recording_folder(
                 save_mediapipe_3d_data_to_npy(
                     data3d_numFrames_numTrackedPoints_XYZ=reprojection_filtered_skel3d_frame_marker_xyz,
                     data3d_numFrames_numTrackedPoints_reprojectionError=reprojection_filtered_skeleton_reprojection_error_fr_mar,
-                    data3d_numCams_numFrames_numTrackedPoints_reprojectionError=reprojection_filtered_skeleton_reprojection_error_fr_mar,
+                    data3d_numCams_numFrames_numTrackedPoints_reprojectionError=reprojection_filtered_skeleton_reprojection_error_cam_fr_mar,
                     path_to_folder_where_data_will_be_saved=rec.recording_info_model.raw_data_folder_path,
                     processing_level="reprojection_filtered",
                 )

--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
@@ -190,6 +190,7 @@ def process_recording_folder(
                     raw_skel3d_frame_marker_xyz=raw_skel3d_frame_marker_xyz,
                     anipose_calibration_object=anipose_calibration_object,
                     use_triangulate_ransac=rec.anipose_triangulate_3d_parameters_model.use_triangulate_ransac_method,
+                    minimum_cameras_to_reproject=rec.anipose_triangulate_3d_parameters_model.minimum_cameras_to_reproject,
                 )
                 save_mediapipe_3d_data_to_npy(
                     data3d_numFrames_numTrackedPoints_XYZ=reprojection_filtered_skel3d_frame_marker_xyz,

--- a/freemocap/data_layer/recording_models/post_processing_parameter_models.py
+++ b/freemocap/data_layer/recording_models/post_processing_parameter_models.py
@@ -20,7 +20,7 @@ class MediapipeParametersModel(BaseModel):
 class AniposeTriangulate3DParametersModel(BaseModel):
     skip_reprojection_error_filtering: bool = True
     reprojection_error_confidence_cutoff: float = 90
-    minimum_cameras_to_reproject: int = 2
+    minimum_cameras_to_reproject: int = 3
     confidence_threshold_cutoff: float = 0.5
     use_triangulate_ransac_method: bool = False
     skip_3d_triangulation: bool = False

--- a/freemocap/data_layer/recording_models/post_processing_parameter_models.py
+++ b/freemocap/data_layer/recording_models/post_processing_parameter_models.py
@@ -20,6 +20,7 @@ class MediapipeParametersModel(BaseModel):
 class AniposeTriangulate3DParametersModel(BaseModel):
     skip_reprojection_error_filtering: bool = True
     reprojection_error_confidence_cutoff: float = 90
+    minimum_cameras_to_reproject: int = 2
     confidence_threshold_cutoff: float = 0.5
     use_triangulate_ransac_method: bool = False
     skip_3d_triangulation: bool = False

--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
@@ -24,7 +24,9 @@ REPROJECTION_ERROR_FILTERING_TREE_NAME = "Reprojection Error Filtering"
 
 SKIP_REPROJECTION_ERROR_FILTERING = "Skip Reprojection Error Filtering"
 
-REPROJECTION_ERROR_FILTER_THRESHOLD = "Reprojection Error Filter Threshold"
+REPROJECTION_ERROR_FILTER_THRESHOLD = "Reprojection Error Filter Threshold (%)"
+
+MINIMUM_CAMERAS_TO_REPROJECT = "Minimum Cameras to Reproject"
 
 ANIPOSE_TREE_NAME = "Anipose Triangulation"
 
@@ -132,16 +134,22 @@ def create_3d_triangulation_prarameter_group(
                         name=SKIP_REPROJECTION_ERROR_FILTERING,
                         type="bool",
                         value=parameter_model.skip_reprojection_error_filtering,
-                        tip="If true, skip filtering of reprojection error."
+                        tip="If true, skip filtering of reprojection error.",
                     ),
                     dict(
                         name=REPROJECTION_ERROR_FILTER_THRESHOLD,
                         type="float",
                         value=parameter_model.reprojection_error_confidence_cutoff,
-                        tip="The maximum reprojection error allowed in the data."
-                    )
-                ]
-            )
+                        tip="The maximum reprojection error allowed in the data.",
+                    ),
+                    dict(
+                        name=MINIMUM_CAMERAS_TO_REPROJECT,
+                        type="int",
+                        value=parameter_model.minimum_cameras_to_reproject,
+                        tip="The minimum number of cameras to reproject during retriangulation.",
+                    ),
+                ],
+            ),
         ],
     )
 

--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
@@ -208,6 +208,7 @@ def extract_parameter_model_from_parameter_tree(
         anipose_triangulate_3d_parameters_model=AniposeTriangulate3DParametersModel(
             skip_reprojection_error_filtering=parameter_values_dictionary[SKIP_REPROJECTION_ERROR_FILTERING],
             reprojection_error_confidence_cutoff=parameter_values_dictionary[REPROJECTION_ERROR_FILTER_THRESHOLD],
+            minimum_cameras_to_reproject=parameter_values_dictionary[MINIMUM_CAMERAS_TO_REPROJECT],
             confidence_threshold_cutoff=parameter_values_dictionary[ANIPOSE_CONFIDENCE_CUTOFF],
             use_triangulate_ransac_method=parameter_values_dictionary[USE_RANSAC_METHOD],
             skip_3d_triangulation=parameter_values_dictionary[SKIP_3D_TRIANGULATION_NAME],

--- a/freemocap/tests/test_by_camera_reprojection_filtering.py
+++ b/freemocap/tests/test_by_camera_reprojection_filtering.py
@@ -1,8 +1,8 @@
 import numpy as np
 
 from freemocap.core_processes.capture_volume_calibration.by_camera_reprojection_filtering import (
-    get_camera_frame_marker_lists_to_reproject,
-    set_unincluded_data_to_nans,
+    _get_camera_frame_marker_lists_to_reproject,
+    _set_unincluded_data_to_nans,
 )
 
 
@@ -15,7 +15,7 @@ def test_get_camera_frame_marker_lists_to_reproject():
     num_cameras_to_remove = 1
     expected_output = ([[2], [1]], [0, 1], [1, 2])
     assert (
-        get_camera_frame_marker_lists_to_reproject(
+        _get_camera_frame_marker_lists_to_reproject(
             reprojError_cam_frame_marker, frame_marker_list, num_cameras_to_remove
         )
         == expected_output
@@ -25,7 +25,7 @@ def test_get_camera_frame_marker_lists_to_reproject():
     num_cameras_to_remove = 2
     expected_output = ([[2, 0], [1, 2]], [0, 1], [1, 2])
     assert (
-        get_camera_frame_marker_lists_to_reproject(
+        _get_camera_frame_marker_lists_to_reproject(
             reprojError_cam_frame_marker, frame_marker_list, num_cameras_to_remove
         )
         == expected_output
@@ -35,7 +35,7 @@ def test_get_camera_frame_marker_lists_to_reproject():
     num_cameras_to_remove = 3
     expected_output = ([[2, 0, 1], [1, 2, 0]], [0, 1], [1, 2])
     assert (
-        get_camera_frame_marker_lists_to_reproject(
+        _get_camera_frame_marker_lists_to_reproject(
             reprojError_cam_frame_marker, frame_marker_list, num_cameras_to_remove
         )
         == expected_output
@@ -46,7 +46,7 @@ def test_get_camera_frame_marker_lists_to_reproject():
     # should just return all of the camera sorted by max reprojection error, no need to error
     expected_output = ([[2, 0, 1], [1, 2, 0]], [0, 1], [1, 2])
     assert (
-        get_camera_frame_marker_lists_to_reproject(
+        _get_camera_frame_marker_lists_to_reproject(
             reprojError_cam_frame_marker, frame_marker_list, num_cameras_to_remove
         )
         == expected_output
@@ -56,7 +56,7 @@ def test_get_camera_frame_marker_lists_to_reproject():
     num_cameras_to_remove = 2
     expected_output = ([], [], [])
     assert (
-        get_camera_frame_marker_lists_to_reproject(
+        _get_camera_frame_marker_lists_to_reproject(
             reprojError_cam_frame_marker, frame_marker_list, num_cameras_to_remove
         )
         == expected_output
@@ -69,7 +69,7 @@ def test_set_unincluded_data_to_nans():
     frames_with_reprojection_error = [1, 2]
     markers_with_reprojection_error = [3, 4]
     cameras_to_remove = [[0, 1], [2, 3]]
-    result = set_unincluded_data_to_nans(data, frames_with_reprojection_error, markers_with_reprojection_error, cameras_to_remove)
+    result = _set_unincluded_data_to_nans(data, frames_with_reprojection_error, markers_with_reprojection_error, cameras_to_remove)
     for cameras, frame, marker in zip(cameras_to_remove, frames_with_reprojection_error, markers_with_reprojection_error):
         for camera in cameras:
             np.testing.assert_array_equal(result[camera, frame, marker, :], np.full((2,), np.nan))
@@ -80,7 +80,7 @@ def test_set_unincluded_data_to_nans():
     markers_with_reprojection_error = [3, 4]
     cameras_to_remove = [[0, 1], [2, 3]]
     original_data = data.copy()
-    result = set_unincluded_data_to_nans(data, frames_with_reprojection_error, markers_with_reprojection_error, cameras_to_remove)
+    result = _set_unincluded_data_to_nans(data, frames_with_reprojection_error, markers_with_reprojection_error, cameras_to_remove)
     mask = np.ones(data.shape, dtype=bool)
     for cameras, frame, marker in zip(cameras_to_remove, frames_with_reprojection_error, markers_with_reprojection_error):
         for camera in cameras:

--- a/freemocap/tests/test_by_camera_reprojection_filtering.py
+++ b/freemocap/tests/test_by_camera_reprojection_filtering.py
@@ -1,0 +1,92 @@
+import numpy as np
+
+from freemocap.core_processes.capture_volume_calibration.by_camera_reprojection_filtering import (
+    get_camera_frame_marker_lists_to_reproject,
+    set_unincluded_data_to_nans,
+)
+
+
+def test_get_camera_frame_marker_lists_to_reproject():
+    # test removing one camera
+    reprojError_cam_frame_marker = np.array(
+        [[[1, 5, 3], [4, 5, 6], [7, 8, 9]], [[2, 3, 4], [5, 6, 9], [8, 9, 10]], [[3, 6, 5], [6, 7, 8], [9, 10, 11]]]
+    )
+    frame_marker_list = [(0, 1), (1, 2)]
+    num_cameras_to_remove = 1
+    expected_output = ([[2], [1]], [0, 1], [1, 2])
+    assert (
+        get_camera_frame_marker_lists_to_reproject(
+            reprojError_cam_frame_marker, frame_marker_list, num_cameras_to_remove
+        )
+        == expected_output
+    )
+    # test removing two cameras
+    frame_marker_list = [(0, 1), (1, 2)]
+    num_cameras_to_remove = 2
+    expected_output = ([[2, 0], [1, 2]], [0, 1], [1, 2])
+    assert (
+        get_camera_frame_marker_lists_to_reproject(
+            reprojError_cam_frame_marker, frame_marker_list, num_cameras_to_remove
+        )
+        == expected_output
+    )
+    # test removing all cameras
+    frame_marker_list = [(0, 1), (1, 2)]
+    num_cameras_to_remove = 3
+    expected_output = ([[2, 0, 1], [1, 2, 0]], [0, 1], [1, 2])
+    assert (
+        get_camera_frame_marker_lists_to_reproject(
+            reprojError_cam_frame_marker, frame_marker_list, num_cameras_to_remove
+        )
+        == expected_output
+    )
+    # test removing more cameras than dimensions
+    frame_marker_list = [(0, 1), (1, 2)]
+    num_cameras_to_remove = 4
+    # should just return all of the camera sorted by max reprojection error, no need to error
+    expected_output = ([[2, 0, 1], [1, 2, 0]], [0, 1], [1, 2])
+    assert (
+        get_camera_frame_marker_lists_to_reproject(
+            reprojError_cam_frame_marker, frame_marker_list, num_cameras_to_remove
+        )
+        == expected_output
+    )
+    # test providing no frames or markers
+    frame_marker_list = []
+    num_cameras_to_remove = 2
+    expected_output = ([], [], [])
+    assert (
+        get_camera_frame_marker_lists_to_reproject(
+            reprojError_cam_frame_marker, frame_marker_list, num_cameras_to_remove
+        )
+        == expected_output
+    )
+
+
+def test_set_unincluded_data_to_nans():
+    # test indices are turned to nans
+    data = np.random.rand(5, 5, 5, 2)
+    frames_with_reprojection_error = [1, 2]
+    markers_with_reprojection_error = [3, 4]
+    cameras_to_remove = [[0, 1], [2, 3]]
+    result = set_unincluded_data_to_nans(data, frames_with_reprojection_error, markers_with_reprojection_error, cameras_to_remove)
+    for cameras, frame, marker in zip(cameras_to_remove, frames_with_reprojection_error, markers_with_reprojection_error):
+        for camera in cameras:
+            np.testing.assert_array_equal(result[camera, frame, marker, :], np.full((2,), np.nan))
+
+    # test other indices aren't touched
+    data = np.random.rand(5, 5, 5, 2)
+    frames_with_reprojection_error = [1, 2]
+    markers_with_reprojection_error = [3, 4]
+    cameras_to_remove = [[0, 1], [2, 3]]
+    original_data = data.copy()
+    result = set_unincluded_data_to_nans(data, frames_with_reprojection_error, markers_with_reprojection_error, cameras_to_remove)
+    mask = np.ones(data.shape, dtype=bool)
+    for cameras, frame, marker in zip(cameras_to_remove, frames_with_reprojection_error, markers_with_reprojection_error):
+        for camera in cameras:
+            mask[camera, frame, marker, :] = False
+    np.testing.assert_array_equal(result[mask], original_data[mask])
+
+
+if __name__ == "__main__":
+    test_get_camera_frame_marker_lists_to_reproject()


### PR DESCRIPTION
This is a an improved version of the calibration filtering step which uses the by-camera reprojection error to retriangulate data based on the camera viewpoint with the worst reprojection error for that frame/marker combination. This version does a single pass through of the data, although I'm hoping to improve it to iterate through until all reprojection errors are below the threshold. The todo list below goes over some current limitations.

TODO:
- [ ] Only retriangulate the data above the threshold. Right now, the entire data is retriangulated, which is more time intensive than only retriangulating the data above the threshold. The difficulty is keeping the data in a shape that is still usable by our triangulate function. The caveat to this is on my machine the initial anipose triangulation is taking 2:26 on the sample data on my machine, and the second pass is taking only :10, despite both saying they are triangulating the same amount of data. I'm not sure what's going on here.
- [x] Continue to iteratively filter until all data is under the threshold or a camera minimum is met. This is fairly straightforward to change, and just requires making sure the same cameras are not chosen on repeated passes for the same frame/marker combos.
- [ ] Potentially change the debug plots. Right now they show the mean across cameras and body marker, but since we are only retriangulating certain frame/marker combos, the overall effect is not shown well. For example, the mean is almost always below the threshold cutoff, as this is calculated across all points instead of the means.

![debug_reprojection_error_filtering](https://github.com/freemocap/freemocap/assets/24758117/e8d0b182-508a-46c0-b1af-bc33b6d54680)
