### PR TITLE
Fix calibration toml finding

### DIFF
--- a/freemocap/core_processes/detecting_things_in_2d_images/mediapipe_stuff/mediapipe_skeleton_detector.py
+++ b/freemocap/core_processes/detecting_things_in_2d_images/mediapipe_stuff/mediapipe_skeleton_detector.py
@@ -36,9 +36,9 @@ face_drawing_spec = mp_drawing.DrawingSpec(thickness=1, circle_radius=1)
 
 class MediaPipeSkeletonDetector:
     def __init__(
-            self,
-            parameter_model: Optional[MediapipeParametersModel] = None,
-            use_tqdm: bool = True,
+        self,
+        parameter_model: Optional[MediapipeParametersModel] = None,
+        use_tqdm: bool = True,
     ):
         if parameter_model is None:
             parameter_model = MediapipeParametersModel()
@@ -62,26 +62,26 @@ class MediaPipeSkeletonDetector:
         self.number_of_face_tracked_points = mp.solutions.face_mesh.FACEMESH_NUM_LANDMARKS_WITH_IRISES
 
         self.number_of_tracked_points_total = (
-                self.number_of_body_tracked_points
-                + self.number_of_left_hand_tracked_points
-                + self.number_of_right_hand_tracked_points
-                + self.number_of_face_tracked_points
+            self.number_of_body_tracked_points
+            + self.number_of_left_hand_tracked_points
+            + self.number_of_right_hand_tracked_points
+            + self.number_of_face_tracked_points
         )
 
     def process_folder_full_of_videos(
-            self,
-            path_to_folder_of_videos_to_process: Union[Path, str],
-            output_data_folder_path: Union[str, Path],
-            kill_event: multiprocessing.Event=None,
-            use_multiprocessing: bool = True,
+        self,
+        path_to_folder_of_videos_to_process: Union[Path, str],
+        output_data_folder_path: Union[str, Path],
+        kill_event: multiprocessing.Event = None,
+        use_multiprocessing: bool = True,
     ) -> Union[np.ndarray, None]:
-
         path_to_folder_of_videos_to_process = Path(path_to_folder_of_videos_to_process)
         logger.info(f"processing videos from: {path_to_folder_of_videos_to_process}")
 
-        tasks = self._create_video_processing_tasks(output_data_folder_path=output_data_folder_path,
-                                                    path_to_folder_of_videos_to_process=path_to_folder_of_videos_to_process,
-                                                    )
+        tasks = self._create_video_processing_tasks(
+            output_data_folder_path=output_data_folder_path,
+            path_to_folder_of_videos_to_process=path_to_folder_of_videos_to_process,
+        )
 
         if use_multiprocessing:
             with multiprocessing.Pool() as pool:
@@ -94,9 +94,10 @@ class MediaPipeSkeletonDetector:
                         break
                 mediapipe2d_single_camera_npy_arrays_list.append(self.process_single_video(*task))
 
-
-        body_world_numCams_numFrames_numTrackedPts_XYZ, data2d_numCams_numFrames_numTrackedPts_XY = self._build_output_numpy_array(
-            mediapipe2d_single_camera_npy_arrays_list)
+        (
+            body_world_numCams_numFrames_numTrackedPts_XYZ,
+            data2d_numCams_numFrames_numTrackedPts_XY,
+        ) = self._build_output_numpy_array(mediapipe2d_single_camera_npy_arrays_list)
 
         self._save_mediapipe2d_data_to_npy(
             data2d_numCams_numFrames_numTrackedPts_XY=data2d_numCams_numFrames_numTrackedPts_XY,
@@ -107,12 +108,12 @@ class MediaPipeSkeletonDetector:
 
     @staticmethod
     def process_single_video(
-            synchronized_video_file_path: Path,
-            output_data_folder_path: Path,
-            mediapipe_parameters_model: MediapipeParametersModel,
-            annotate_image: Callable,
-            list_of_mediapipe_results_to_npy_arrays: Callable,
-            use_tqdm: bool = True,
+        synchronized_video_file_path: Path,
+        output_data_folder_path: Path,
+        mediapipe_parameters_model: MediapipeParametersModel,
+        annotate_image: Callable,
+        list_of_mediapipe_results_to_npy_arrays: Callable,
+        use_tqdm: bool = True,
     ):
         logger.info(f"Running `mediapipe` skeleton detection on video: {str(synchronized_video_file_path)}")
 
@@ -165,7 +166,7 @@ class MediaPipeSkeletonDetector:
             confidence_threshold = 0.5
 
             threshold_mask = (
-                    mediapipe_single_frame_npy_data.body_frameNumber_trackedPointNumber_confidence < confidence_threshold
+                mediapipe_single_frame_npy_data.body_frameNumber_trackedPointNumber_confidence < confidence_threshold
             )
             mediapipe_single_frame_npy_data.body_frameNumber_trackedPointNumber_XYZ[threshold_mask, :] = np.nan
 
@@ -174,7 +175,6 @@ class MediaPipeSkeletonDetector:
             video_annotated_images_list.append(annotated_image)
 
             success, image = video_capture_object.read()
-
 
         try:
             annotated_video_path = output_data_folder_path.parent.parent / ANNOTATED_VIDEOS_FOLDER_NAME
@@ -259,10 +259,11 @@ class MediaPipeSkeletonDetector:
             )
         return body_world_numCams_numFrames_numTrackedPts_XYZ, data2d_numCams_numFrames_numTrackedPts_XY
 
-    def _create_video_processing_tasks(self,
-                                       output_data_folder_path: Union[str, Path],
-                                       path_to_folder_of_videos_to_process: Union[Path, str],
-                                       ) -> List[Tuple]:
+    def _create_video_processing_tasks(
+        self,
+        output_data_folder_path: Union[str, Path],
+        path_to_folder_of_videos_to_process: Union[Path, str],
+    ) -> List[Tuple]:
         video_paths = get_video_paths(path_to_folder_of_videos_to_process)
         tasks = [
             (
@@ -273,16 +274,15 @@ class MediaPipeSkeletonDetector:
                 self._list_of_mediapipe_results_to_npy_arrays,
                 self._use_tqdm,
             )
-
             for video_path in video_paths
         ]
         return tasks
 
     def _save_mediapipe2d_data_to_npy(
-            self,
-            data2d_numCams_numFrames_numTrackedPts_XY: np.ndarray,
-            body_world_numCams_numFrames_numTrackedPts_XYZ: np.ndarray,
-            output_data_folder_path: Union[str, Path],
+        self,
+        data2d_numCams_numFrames_numTrackedPts_XY: np.ndarray,
+        body_world_numCams_numFrames_numTrackedPts_XYZ: np.ndarray,
+        output_data_folder_path: Union[str, Path],
     ):
         mediapipe_2dData_save_path = Path(output_data_folder_path) / MEDIAPIPE_2D_NPY_FILE_NAME
         mediapipe_2dData_save_path.parent.mkdir(exist_ok=True, parents=True)
@@ -334,10 +334,10 @@ class MediaPipeSkeletonDetector:
         return image
 
     def _list_of_mediapipe_results_to_npy_arrays(
-            self,
-            mediapipe_results_list: List,
-            image_width: Union[int, float],
-            image_height: Union[int, float],
+        self,
+        mediapipe_results_list: List,
+        image_width: Union[int, float],
+        image_height: Union[int, float],
     ) -> Mediapipe2dNumpyArrays:
         number_of_frames = len(mediapipe_results_list)
         number_of_spatial_dimensions = 3  # this will be 2d XY pixel data, with mediapipe's estimate of Z
@@ -403,14 +403,14 @@ class MediaPipeSkeletonDetector:
             if frame_results.pose_landmarks is not None:
                 for landmark_number, landmark_data in enumerate(frame_results.pose_landmarks.landmark):
                     body_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 0] = (
-                            landmark_data.x * image_width
+                        landmark_data.x * image_width
                     )
                     body_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 1] = (
-                            landmark_data.y * image_height
+                        landmark_data.y * image_height
                     )
                     body_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 2] = (
-                            landmark_data.z
-                            * image_width
+                        landmark_data.z
+                        * image_width
                         # z is on roughly the same scale as x, according to mediapipe docs
                     )
                     body_frameNumber_trackedPointNumber_confidence[
@@ -419,52 +419,52 @@ class MediaPipeSkeletonDetector:
 
                 for landmark_number, landmark_data in enumerate(frame_results.pose_world_landmarks.landmark):
                     body_world_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 0] = (
-                            landmark_data.x * image_width
+                        landmark_data.x * image_width
                     )
                     body_world_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 1] = (
-                            landmark_data.y * image_height
+                        landmark_data.y * image_height
                     )
                     body_world_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 2] = (
-                            landmark_data.z * image_width
+                        landmark_data.z * image_width
                     )
 
             # get Right Hand data
             if frame_results.right_hand_landmarks is not None:
                 for landmark_number, landmark_data in enumerate(frame_results.right_hand_landmarks.landmark):
                     rightHand_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 0] = (
-                            landmark_data.x * image_width
+                        landmark_data.x * image_width
                     )
                     rightHand_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 1] = (
-                            landmark_data.y * image_height
+                        landmark_data.y * image_height
                     )
                     rightHand_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 2] = (
-                            landmark_data.z * image_width
+                        landmark_data.z * image_width
                     )
 
             # get Left Hand data
             if frame_results.left_hand_landmarks is not None:
                 for landmark_number, landmark_data in enumerate(frame_results.left_hand_landmarks.landmark):
                     leftHand_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 0] = (
-                            landmark_data.x * image_width
+                        landmark_data.x * image_width
                     )
                     leftHand_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 1] = (
-                            landmark_data.y * image_height
+                        landmark_data.y * image_height
                     )
                     leftHand_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 2] = (
-                            landmark_data.z * image_width
+                        landmark_data.z * image_width
                     )
 
             # get Face data
             if frame_results.face_landmarks is not None:
                 for landmark_number, landmark_data in enumerate(frame_results.face_landmarks.landmark):
                     face_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 0] = (
-                            landmark_data.x * image_width
+                        landmark_data.x * image_width
                     )
                     face_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 1] = (
-                            landmark_data.y * image_height
+                        landmark_data.y * image_height
                     )
                     face_frameNumber_trackedPointNumber_XYZ[frame_number, landmark_number, 2] = (
-                            landmark_data.z * image_width
+                        landmark_data.z * image_width
                     )
 
             # check if all tracked points are visible on this frame

--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
@@ -54,10 +54,10 @@ logger = logging.getLogger(__name__)
 
 
 def process_recording_folder(
-        recording_processing_parameter_model: PostProcessingParameterModel,
-        kill_event: multiprocessing.Event=None,
-        queue: multiprocessing.Queue = None,
-        use_tqdm: bool = True,
+    recording_processing_parameter_model: PostProcessingParameterModel,
+    kill_event: multiprocessing.Event = None,
+    queue: multiprocessing.Queue = None,
+    use_tqdm: bool = True,
 ):
     """
 
@@ -202,7 +202,7 @@ def process_recording_folder(
         array_to_save=segment_COM_frame_imgPoint_XYZ,
         skeleton_file_name=SEGMENT_CENTER_OF_MASS_NPY_FILE_NAME,
         path_to_folder_where_we_will_save_this_data=Path(path_to_folder_where_we_will_save_this_data)
-                                                    / CENTER_OF_MASS_FOLDER_NAME,
+        / CENTER_OF_MASS_FOLDER_NAME,
     )
 
     logger.info("Saving total body center of mass data")
@@ -210,7 +210,7 @@ def process_recording_folder(
         array_to_save=totalBodyCOM_frame_XYZ,
         skeleton_file_name=TOTAL_BODY_CENTER_OF_MASS_NPY_FILE_NAME,
         path_to_folder_where_we_will_save_this_data=Path(path_to_folder_where_we_will_save_this_data)
-                                                    / CENTER_OF_MASS_FOLDER_NAME,
+        / CENTER_OF_MASS_FOLDER_NAME,
     )
 
     try:
@@ -230,7 +230,7 @@ def process_recording_folder(
     )
 
     path_to_skeleton_body_csv = (
-            Path(rec.recording_info_model.output_data_folder_path) / MEDIAPIPE_BODY_3D_DATAFRAME_CSV_FILE_NAME
+        Path(rec.recording_info_model.output_data_folder_path) / MEDIAPIPE_BODY_3D_DATAFRAME_CSV_FILE_NAME
     )
     skeleton_dataframe = pd.read_csv(path_to_skeleton_body_csv)
 

--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_headless.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_headless.py
@@ -1,5 +1,4 @@
 import logging
-import multiprocessing
 from pathlib import Path
 from typing import Optional, Union
 


### PR DESCRIPTION
This PR fixes the problem we've had with not being able to automatically find the calibration toml paths of an active recording session. If a path is not found at `SESSION_NAME_camera_calibration.toml`, it checks the active recording folder for another file that ends with `camera_calibration.toml`. If it finds one, it sets that to the calibration path for the active recording, and if not it defaults to the most recent calibration. 

It also fixes the linting that got pushed this morning, which is why it touches some files unrelated to the calibration path.