### PR TITLE
Update opencv version to 4.8

### DIFF
--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Callable, Union
 
 import numpy as np
-from aniposelib.boards import CharucoBoard as AniposeCharucoBoard
 
 from freemocap.core_processes.capture_volume_calibration.anipose_camera_calibration import (
     freemocap_anipose,
@@ -59,7 +58,7 @@ class AniposeCameraCalibrator:
         )
         self._anipose_camera_group_object.metadata["date_time_calibrated"] = str(np.datetime64("now"))
 
-        self._anipose_charuco_board = AniposeCharucoBoard(
+        self._anipose_charuco_board = freemocap_anipose.AniposeCharucoBoard(
             self._charuco_board_object.number_of_squares_width,
             self._charuco_board_object.number_of_squares_height,
             square_length=self._charuco_square_size,  # mm

--- a/freemocap/core_processes/capture_volume_calibration/charuco_stuff/charuco_board_definition.py
+++ b/freemocap/core_processes/capture_volume_calibration/charuco_stuff/charuco_board_definition.py
@@ -6,36 +6,19 @@ import cv2
 
 @dataclass
 class CharucoBoardDefinition:
-    try:
-        # to make compatible across opencv 4.6 and 4.7
-        aruco_marker_dict: Dict = cv2.aruco.Dictionary_get(cv2.aruco.DICT_4X4_250)
-    except Exception:
-        aruco_marker_dict: Dict = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250)
+    aruco_marker_dict: Dict = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250)
 
-    # number_of_squares_width: int = 5
-    # number_of_squares_height: int = 3
     number_of_squares_width: int = 7
     number_of_squares_height: int = 5
     black_square_side_length: int = 1
     aruco_marker_length_proportional: float = 0.8
 
     def __post_init__(self):
-        try:
-            # opencv 4.6
-            self.charuco_board = cv2.aruco.CharucoBoard_create(
-                self.number_of_squares_width,
-                self.number_of_squares_height,
-                self.black_square_side_length,
-                self.aruco_marker_length_proportional,
-                self.aruco_marker_dict,
-            )
-        except Exception:
-            # opencv 4.7
-            self.charuco_board = cv2.aruco.CharucoBoard(
-                size=[self.number_of_squares_width, self.number_of_squares_height],
-                squareLength=self.black_square_side_length,
-                markerLength=self.aruco_marker_length_proportional,
-                dictionary=self.aruco_marker_dict,
-            )
+        self.charuco_board = cv2.aruco.CharucoBoard(
+            size=[self.number_of_squares_width, self.number_of_squares_height],
+            squareLength=self.black_square_side_length,
+            markerLength=self.aruco_marker_length_proportional,
+            dictionary=self.aruco_marker_dict,
+        )
 
         self.number_of_charuco_corners = (self.number_of_squares_width - 1) * (self.number_of_squares_height - 1)

--- a/freemocap/gui/qt/widgets/home_widget.py
+++ b/freemocap/gui/qt/widgets/home_widget.py
@@ -110,7 +110,7 @@ class HomeWidget(QWidget):
         hbox.addWidget(version_label)
 
     def check_for_latest_version(self) -> Union[str, None]:
-        response = requests.get(f"https://pypi.org/pypi/{freemocap.__package_name__}/json")
+        response = requests.get(f"https://pypi.org/pypi/{freemocap.__package_name__}/json", timeout=(5, 60))
         if response.status_code != 200:
             logger.error(f"Failed to check for latest version of {freemocap.__package_name__}")
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
     "skellyforge",
     "skelly_synchronize",
     "mediapipe",
-    "opencv-contrib-python==4.6.0.66",
+    "opencv-contrib-python==4.8.*",
     "toml==0.10.2",
     "aniposelib==0.4.3",
     "libsass==0.21.0",


### PR DESCRIPTION
We've had opencv pinned to version `4.6.*`, despite having `try/except` blocks that handle the namespace changes from versions `> 4.6.*`. This update changes the version to 4.8 to allow us to benefit from ongoing updates to the charuco functionality in opencv.

Unfortunately, we can not change the dependency from `opencv-contrib-python` to `opencv-python` as we had originally hoped, because both mediapipe and anipose rely on `opencv-contrib-python`, so it will only add an additional dependency. 