### PR TITLE
Don't run linting with nox version testing

### DIFF
--- a/.github/workflows/version-testing.yml
+++ b/.github/workflows/version-testing.yml
@@ -22,4 +22,4 @@ jobs:
           sudo apt-get install libegl1-mesa
       - name: Run noxfile
         run: |
-          nox
+          nox --session test coverage


### PR DESCRIPTION
I keep noticing Nox tests fail just because the linting fails. This is undesirable because it duplicates tests, and it makes it unclear if the version testing failed because of the version testing or because of the linting. This PR changes the noxfile to only run the version testing and coverage tests.