### PR TITLE
Philip + Trent: window sizing

### DIFF
--- a/freemocap/.idea/workspace.xml
+++ b/freemocap/.idea/workspace.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="664e9f86-ca5f-498e-a2a6-51de9dcdf5f5" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/icon_support.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../bin/installer.sh" beforeDir="false" afterPath="$PROJECT_DIR$/../bin/installer.sh" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/__init__.py" beforeDir="false" afterPath="$PROJECT_DIR$/__init__.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/__main__.py" beforeDir="false" afterPath="$PROJECT_DIR$/__main__.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/gui/qt/freemocap_main.py" beforeDir="false" afterPath="$PROJECT_DIR$/gui/qt/freemocap_main.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../pyproject.toml" beforeDir="false" afterPath="$PROJECT_DIR$/../pyproject.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../src/gui/main/main.py" beforeDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$/.." />
+  </component>
+  <component name="ProjectId" id="2Q7DQUROvd4MGSbQZemEdrlKZQ8" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/jon/github_repos/freemocap_organization/freemocap/freemocap&quot;
+  }
+}</component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="664e9f86-ca5f-498e-a2a6-51de9dcdf5f5" name="Changes" comment="" />
+      <created>1684695709495</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1684695709495</updated>
+    </task>
+    <servers />
+  </component>
+</project>

--- a/freemocap/gui/qt/main_window/freemocap_main_window.py
+++ b/freemocap/gui/qt/main_window/freemocap_main_window.py
@@ -181,7 +181,7 @@ class MainWindow(QMainWindow):
         height = screen.height() * height_fraction
         self.setFixedSize(int(width), int(height))
         self.setMinimumSize(1280, 720)
-        self.setMaximumSize(int(width*2), int(height*2))
+        self.setMaximumSize(int(width * 2), int(height * 2))
 
     def _create_tools_dock_widget(self):
         tools_dock_widget = QDockWidget("Control Panel", self)

--- a/freemocap/gui/qt/main_window/freemocap_main_window.py
+++ b/freemocap/gui/qt/main_window/freemocap_main_window.py
@@ -97,7 +97,7 @@ class MainWindow(QMainWindow):
         self._log_view_widget = LogViewWidget(parent=self)  # start this first so it will grab the setup logs
         logger.info("Initializing FreeMoCap MainWindow")
 
-        self.setGeometry(100, 100, 1280, 720)
+        self._size_main_window(width_fraction=1, height_fraction=0.95)
         self.setWindowIcon(QIcon(PATH_TO_FREEMOCAP_LOGO_SVG))
         self.setWindowTitle("freemocap \U0001F480 \U00002728")
 
@@ -179,10 +179,9 @@ class MainWindow(QMainWindow):
 
         width = screen.width() * width_fraction
         height = screen.height() * height_fraction
-        # Position the window in the center of the screen
-        left = (screen.width() - width) / 2
-        top = (screen.height() - height) / 2
-        self.setGeometry(int(left), int(top), int(width), int(height))
+        self.setFixedSize(int(width), int(height))
+        self.setMinimumSize(1280, 720)
+        self.setMaximumSize(int(width*2), int(height*2))
 
     def _create_tools_dock_widget(self):
         tools_dock_widget = QDockWidget("Control Panel", self)

--- a/freemocap/gui/qt/widgets/control_panel/control_panel_dock_widget.py
+++ b/freemocap/gui/qt/widgets/control_panel/control_panel_dock_widget.py
@@ -33,7 +33,6 @@ class ControlPanelWidget(QWidget):
     def __init__(
         self,
         camera_configuration_parameter_tree_widget: SkellyCamParameterTreeWidget,
-        # calibration_control_panel: CalibrationControlPanel,
         process_motion_capture_data_panel: ProcessMotionCaptureDataPanel,
         visualize_data_widget: QWidget,
         parent=None,
@@ -50,7 +49,6 @@ class ControlPanelWidget(QWidget):
             camera_configuration_parameter_tree_widget,
             "Camera Configuration",
         )
-        # self._tool_box.addTab(calibration_control_panel, "Capture Volume Calibration")
         self._tab_widget.addTab(process_motion_capture_data_panel, "Process Data")
         self._tab_widget.addTab(visualize_data_widget, "Export Data")
 

--- a/freemocap/gui/qt/widgets/home_widget.py
+++ b/freemocap/gui/qt/widgets/home_widget.py
@@ -16,7 +16,6 @@ from packaging import version
 import freemocap
 from freemocap.gui.qt.actions_and_menus.actions import (
     CREATE_NEW_RECORDING_ACTION_NAME,
-    LOAD_MOST_RECENT_RECORDING_ACTION_NAME,
     LOAD_RECORDING_ACTION_NAME,
     IMPORT_VIDEOS_ACTION_NAME,
     Actions,

--- a/freemocap/gui/qt/widgets/home_widget.py
+++ b/freemocap/gui/qt/widgets/home_widget.py
@@ -3,7 +3,6 @@ from typing import Union
 
 import requests
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QPixmap
 from PyQt6.QtWidgets import (
     QCheckBox,
     QLabel,
@@ -23,6 +22,7 @@ from freemocap.gui.qt.actions_and_menus.actions import (
     Actions,
 )
 from freemocap.gui.qt.utilities.save_and_load_gui_state import GuiState, save_gui_state
+from freemocap.gui.qt.widgets.image_widget import ImageWidget
 
 from freemocap.system.paths_and_filenames.file_and_folder_names import PATH_TO_FREEMOCAP_LOGO_SVG
 from freemocap.system.paths_and_filenames.path_getters import get_gui_state_json_path
@@ -49,8 +49,6 @@ class HomeWidget(QWidget):
         self.sizePolicy().setHorizontalStretch(1)
         self.sizePolicy().setVerticalStretch(1)
 
-        self._layout.addStretch(1)
-
         self._add_freemocap_logo()
 
         self._welcome_to_freemocap_title_widget = self._welcome_to_freemocap_title()
@@ -61,10 +59,6 @@ class HomeWidget(QWidget):
         self._layout.addWidget(self._create_new_session_button, alignment=Qt.AlignmentFlag.AlignCenter)
         self._create_new_session_button.setProperty("recommended_next", True)
 
-        self._load_most_recent_session_button = WelcomeScreenButton(f"{LOAD_MOST_RECENT_RECORDING_ACTION_NAME}")
-        # self._load_most_recent_session_button.clicked.connect(actions.load_most_recent_recording_action.trigger)
-        # self._layout.addWidget(self._load_most_recent_session_button, alignment=Qt.AlignmentFlag.AlignCenter)
-        #
         self._load_existing_session_button = WelcomeScreenButton(f"{LOAD_RECORDING_ACTION_NAME}")
         self._load_existing_session_button.clicked.connect(actions.load_existing_recording_action.trigger)
         self._layout.addWidget(self._load_existing_session_button, alignment=Qt.AlignmentFlag.AlignCenter)
@@ -72,8 +66,6 @@ class HomeWidget(QWidget):
         self._import_videos_button = WelcomeScreenButton(f"{IMPORT_VIDEOS_ACTION_NAME}")
         self._import_videos_button.clicked.connect(actions.import_videos_action.trigger)
         self._layout.addWidget(self._import_videos_button, alignment=Qt.AlignmentFlag.AlignCenter)
-
-        # self._layout.addStretch(1)
 
         self._create_user_info_consent_checkbox()
 
@@ -181,12 +173,6 @@ class HomeWidget(QWidget):
         return session_title_label
 
     def _add_freemocap_logo(self):
-        freemocap_logo_label = QLabel(self)
-        freemocap_logo_label.sizePolicy().setHorizontalStretch(1)
-        freemocap_logo_label.sizePolicy().setVerticalStretch(1)
+        freemocap_logo_label = ImageWidget(image_path=PATH_TO_FREEMOCAP_LOGO_SVG)
         self._layout.addWidget(freemocap_logo_label)
-
-        freemocap_logo_pixmap = QPixmap(PATH_TO_FREEMOCAP_LOGO_SVG)
-        freemocap_logo_pixmap = freemocap_logo_pixmap.scaledToWidth(200)
-        freemocap_logo_label.setPixmap(freemocap_logo_pixmap)
-        freemocap_logo_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        freemocap_logo_label.raise_()

--- a/freemocap/gui/qt/widgets/home_widget.py
+++ b/freemocap/gui/qt/widgets/home_widget.py
@@ -179,4 +179,3 @@ class HomeWidget(QWidget):
     def _add_freemocap_logo(self):
         freemocap_logo_label = ImageWidget(image_path=PATH_TO_FREEMOCAP_LOGO_SVG, scaling_factor=0.88)
         self._layout.addWidget(freemocap_logo_label)
-        freemocap_logo_label.raise_()

--- a/freemocap/gui/qt/widgets/home_widget.py
+++ b/freemocap/gui/qt/widgets/home_widget.py
@@ -46,6 +46,8 @@ class HomeWidget(QWidget):
         self._layout = QVBoxLayout()
         self.setLayout(self._layout)
 
+        self._layout.setContentsMargins(0, 0, 0, 0)
+
         self.sizePolicy().setHorizontalStretch(1)
         self.sizePolicy().setVerticalStretch(1)
 
@@ -173,6 +175,6 @@ class HomeWidget(QWidget):
         return session_title_label
 
     def _add_freemocap_logo(self):
-        freemocap_logo_label = ImageWidget(image_path=PATH_TO_FREEMOCAP_LOGO_SVG)
+        freemocap_logo_label = ImageWidget(image_path=PATH_TO_FREEMOCAP_LOGO_SVG, scaling_factor=0.88)
         self._layout.addWidget(freemocap_logo_label)
         freemocap_logo_label.raise_()

--- a/freemocap/gui/qt/widgets/image_widget.py
+++ b/freemocap/gui/qt/widgets/image_widget.py
@@ -2,8 +2,9 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QPixmap, QImage
 from PyQt6.QtWidgets import QWidget, QLabel, QVBoxLayout
 
+
 class ImageWidget(QWidget):
-    def __init__(self, image_path: str):
+    def __init__(self, image_path: str, scaling_factor: float = 0.85):
         super().__init__()
         self.image = QImage(image_path)
         self.label = QLabel()
@@ -12,7 +13,7 @@ class ImageWidget(QWidget):
         self.layout = QVBoxLayout()
         self.layout.addWidget(self.label)
         self.setLayout(self.layout)
-        self.scaling_factor = 0.85
+        self.scaling_factor = scaling_factor
 
     def resizeEvent(self, event):
         self.label.setPixmap(

--- a/freemocap/gui/qt/widgets/image_widget.py
+++ b/freemocap/gui/qt/widgets/image_widget.py
@@ -1,0 +1,20 @@
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QPixmap, QImage
+from PyQt6.QtWidgets import QWidget, QLabel, QVBoxLayout
+
+class ImageWidget(QWidget):
+    def __init__(self, image_path: str):
+        super().__init__()
+        self.image = QImage(image_path)
+        self.label = QLabel()
+        self.label.setPixmap(QPixmap.fromImage(self.image))
+        self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.layout = QVBoxLayout()
+        self.layout.addWidget(self.label)
+        self.setLayout(self.layout)
+        self.scaling_factor = 0.85
+
+    def resizeEvent(self, event):
+        self.label.setPixmap(
+            QPixmap.fromImage(self.image).scaled(self.size() * self.scaling_factor, Qt.AspectRatioMode.KeepAspectRatio)
+        )


### PR DESCRIPTION
Fixes #463. Makes the window the size of the primary screen when opening, and makes it resizeable to some reasonable minimums and maximums. Also has skelly resize to mostly stay an appropriate size without cutting off.
![Screen Shot 2023-10-03 at 5 15 08 PM](https://github.com/freemocap/freemocap/assets/24758117/bf5751df-5d09-44bd-82f3-e095702c77e0)
