### PR TITLE
PATCH: offline failure

### DIFF
--- a/freemocap/gui/qt/main_window/freemocap_main_window.py
+++ b/freemocap/gui/qt/main_window/freemocap_main_window.py
@@ -516,10 +516,11 @@ class MainWindow(QMainWindow):
         self.download_sample_data_thread_worker.finished.connect(self._handle_download_sample_data_finished)
 
     def _handle_download_sample_data_finished(self):
-        logger.info("Setting sample data as active recording... ")
-        self._active_recording_info_widget.set_active_recording(
-            recording_folder_path=self.download_sample_data_thread_worker.sample_data_path
-        )
+        if self.download_sample_data_thread_worker.success:
+            logger.info("Setting sample data as active recording... ")
+            self._active_recording_info_widget.set_active_recording(
+                recording_folder_path=self.download_sample_data_thread_worker.sample_data_path
+            )
 
     @pyqtSlot(list, str, bool)
     def _handle_import_videos(self, video_paths: List[str], folder_to_save_videos: str, synchronization_bool: bool):

--- a/freemocap/gui/qt/widgets/home_widget.py
+++ b/freemocap/gui/qt/widgets/home_widget.py
@@ -86,7 +86,9 @@ class HomeWidget(QWidget):
         hbox = QHBoxLayout()
         self._layout.addLayout(hbox)
         version_label_string = f'source:<a href="https://github.com/freemocap/freemocap" style="color: #777777;"> {freemocap.__version__}</a>'
-        latest_version = self.check_for_latest_version().split("rc")[0]
+        latest_version = self.check_for_latest_version()
+        if latest_version is not None:
+            latest_version = latest_version.split("rc")[0]
         current_version = freemocap.__version__.strip("v").split("-")[0]
 
         if latest_version is None:
@@ -111,8 +113,9 @@ class HomeWidget(QWidget):
         hbox.addWidget(version_label)
 
     def check_for_latest_version(self) -> Union[str, None]:
-        response = requests.get(f"https://pypi.org/pypi/{freemocap.__package_name__}/json", timeout=(5, 60))
-        if response.status_code != 200:
+        try:
+            response = requests.get(f"https://pypi.org/pypi/{freemocap.__package_name__}/json", timeout=(5, 60))
+        except requests.RequestException:
             logger.error(f"Failed to check for latest version of {freemocap.__package_name__}")
             return None
 

--- a/freemocap/gui/qt/workers/download_sample_data_thread_worker.py
+++ b/freemocap/gui/qt/workers/download_sample_data_thread_worker.py
@@ -35,7 +35,7 @@ class DownloadSampleDataThreadWorker(QThread):
             self.success = True
             logger.info("Sample data successfully downloaded")
 
-        except Exception as e:
+        except Exception as e: # noqa
             self.success = False
             logger.error("Something went wrong while downloading sample data")
 

--- a/freemocap/gui/qt/workers/download_sample_data_thread_worker.py
+++ b/freemocap/gui/qt/workers/download_sample_data_thread_worker.py
@@ -32,12 +32,12 @@ class DownloadSampleDataThreadWorker(QThread):
 
         try:
             self.sample_data_path = download_sample_data(sample_data_zip_file_url=FIGSHARE_SAMPLE_ZIP_FILE_URL)
+            self.success = True
+            logger.info("Sample data successfully downloaded")
 
         except Exception as e:
-            logger.exception("Something went wrong while downloading sample data")
-            logger.exception(e)
+            self.success = False
+            logger.error("Something went wrong while downloading sample data")
 
         self.finished.emit()
         self._work_done = True
-
-        logger.info("Sample data successfully downloaded")

--- a/freemocap/system/user_data/pipedream_pings.py
+++ b/freemocap/system/user_data/pipedream_pings.py
@@ -27,5 +27,4 @@ class PipedreamPings:
         try:
             requests.post(self._pipedream_url, json=self._pings_dict, timeout=(5, 60))
         except requests.RequestException:
-            logger.error(f"Failed to send anonymous ping to pipedream")
-
+            logger.error("Failed to send anonymous ping to pipedream")

--- a/freemocap/system/user_data/pipedream_pings.py
+++ b/freemocap/system/user_data/pipedream_pings.py
@@ -24,4 +24,8 @@ class PipedreamPings:
             f"{self._pings_dict} "
         )
 
-        requests.post(self._pipedream_url, json=self._pings_dict, timeout=(5, 60))
+        try:
+            requests.post(self._pipedream_url, json=self._pings_dict, timeout=(5, 60))
+        except requests.RequestException:
+            logger.error(f"Failed to send anonymous ping to pipedream")
+

--- a/freemocap/utilities/download_sample_data.py
+++ b/freemocap/utilities/download_sample_data.py
@@ -44,8 +44,10 @@ def download_sample_data(sample_data_zip_file_url: str = FIGSHARE_TEST_ZIP_FILE_
 
     except requests.exceptions.RequestException as e:
         logger.error(f"Request failed: {e}")
+        raise e
     except zipfile.BadZipFile as e:
         logger.error(f"Failed to unzip the file: {e}")
+        raise e
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patches the issue brought up on Discord that the gui will not currently open if the user's computer is not connected to the internet. I've added exception catching for the version checking and pipedream pings to fail gracefully when not connected to the internet. I've also changed the error handling with the sample data downloading to fail gracefully there as well.