### PR TITLE
patch calibration on fresh install

### DIFF
--- a/freemocap/data_layer/recording_models/recording_info_model.py
+++ b/freemocap/data_layer/recording_models/recording_info_model.py
@@ -21,6 +21,7 @@ from freemocap.tests.test_image_tracking_data_shape import test_image_tracking_d
 from freemocap.tests.test_mediapipe_skeleton_data_shape import test_mediapipe_skeleton_data_shape
 from freemocap.tests.test_synchronized_video_frame_counts import test_synchronized_video_frame_counts
 from freemocap.tests.test_total_body_center_of_mass_data_shape import test_total_body_center_of_mass_data_shape
+from freemocap.utilities.get_video_paths import get_video_paths
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +132,10 @@ class RecordingInfoModel:
         return self._recording_folder_status_checker.check_synchronized_videos_status()
 
     @property
+    def single_video_check(self) -> bool:
+        return self._recording_folder_status_checker.check_single_video()
+
+    @property
     def data2d_status_check(self) -> bool:
         return self._recording_folder_status_checker.check_data2d_status()
 
@@ -167,6 +172,12 @@ class RecordingFolderStatusChecker:
             test_synchronized_video_frame_counts(self.recording_info_model.synchronized_videos_folder_path)
             return True
         except AssertionError:
+            return False
+
+    def check_single_video(self) -> bool:
+        if len(get_video_paths(path_to_video_folder=self.recording_info_model.synchronized_videos_folder_path)) == 1:
+            return True
+        else:
             return False
 
     def check_data2d_status(self) -> bool:

--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/process_motion_capture_data_panel.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/process_motion_capture_data_panel.py
@@ -225,17 +225,22 @@ class ProcessMotionCaptureDataPanel(QWidget):
         if not Path(session_parameter_model.recording_info_model.path).exists():
             logger.error(f"Recording path does not exist: {session_parameter_model.recording_info_model.path}.")
             return
-        
-        if session_parameter_model.recording_info_model.single_video_check == False:
+
+        if session_parameter_model.recording_info_model.single_video_check is False:
             selected_camera_calibration_toml_path = self._calibration_control_panel.calibration_toml_path
             session_parameter_model.recording_info_model.calibration_toml_path = selected_camera_calibration_toml_path
 
             # check if there is already a calibration toml  in the recording folder, if not save this one there
             if len(list(Path(session_parameter_model.recording_info_model.path).glob("*.toml"))) == 0:
                 # copy the calibration toml to the recording folder (keeping the original filename
-                logger.info(f"Copying calibration toml from {selected_camera_calibration_toml_path} to {session_parameter_model.recording_info_model.path}")
+                logger.info(
+                    f"Copying calibration toml from {selected_camera_calibration_toml_path} to {session_parameter_model.recording_info_model.path}"
+                )
                 Path(session_parameter_model.recording_info_model.path).mkdir(parents=True, exist_ok=True)
-                copied_toml_path = Path(session_parameter_model.recording_info_model.path) / Path(selected_camera_calibration_toml_path).name
+                copied_toml_path = (
+                    Path(session_parameter_model.recording_info_model.path)
+                    / Path(selected_camera_calibration_toml_path).name
+                )
                 shutil.copyfile(selected_camera_calibration_toml_path, copied_toml_path)
 
         self._process_motion_capture_data_thread_worker = ProcessMotionCaptureDataThreadWorker(

--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/process_motion_capture_data_panel.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/process_motion_capture_data_panel.py
@@ -225,17 +225,18 @@ class ProcessMotionCaptureDataPanel(QWidget):
         if not Path(session_parameter_model.recording_info_model.path).exists():
             logger.error(f"Recording path does not exist: {session_parameter_model.recording_info_model.path}.")
             return
+        
+        if session_parameter_model.recording_info_model.single_video_check == False:
+            selected_camera_calibration_toml_path = self._calibration_control_panel.calibration_toml_path
+            session_parameter_model.recording_info_model.calibration_toml_path = selected_camera_calibration_toml_path
 
-        selected_camera_calibration_toml_path = self._calibration_control_panel.calibration_toml_path
-        session_parameter_model.recording_info_model.calibration_toml_path = selected_camera_calibration_toml_path
-
-        # check if there is already a calibration toml  in the recording folder, if not save this one there
-        if len(list(Path(session_parameter_model.recording_info_model.path).glob("*.toml"))) == 0:
-            # copy the calibration toml to the recording folder (keeping the original filename
-            logger.info(f"Copying calibration toml from {selected_camera_calibration_toml_path} to {session_parameter_model.recording_info_model.path}")
-            Path(session_parameter_model.recording_info_model.path).mkdir(parents=True, exist_ok=True)
-            copied_toml_path = Path(session_parameter_model.recording_info_model.path) / Path(selected_camera_calibration_toml_path).name
-            shutil.copyfile(selected_camera_calibration_toml_path, copied_toml_path)
+            # check if there is already a calibration toml  in the recording folder, if not save this one there
+            if len(list(Path(session_parameter_model.recording_info_model.path).glob("*.toml"))) == 0:
+                # copy the calibration toml to the recording folder (keeping the original filename
+                logger.info(f"Copying calibration toml from {selected_camera_calibration_toml_path} to {session_parameter_model.recording_info_model.path}")
+                Path(session_parameter_model.recording_info_model.path).mkdir(parents=True, exist_ok=True)
+                copied_toml_path = Path(session_parameter_model.recording_info_model.path) / Path(selected_camera_calibration_toml_path).name
+                shutil.copyfile(selected_camera_calibration_toml_path, copied_toml_path)
 
         self._process_motion_capture_data_thread_worker = ProcessMotionCaptureDataThreadWorker(
             session_parameter_model, kill_event=self._kill_thread_event


### PR DESCRIPTION
Adds a check to the recording info model to see if the synchronized videos folder has only one video, and then checks in the process data panel if there is a single video before running any of the calibration toml code