### PR TITLE
Patch memory issues on runners

### DIFF
--- a/.github/workflows/version-testing.yml
+++ b/.github/workflows/version-testing.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@main
       - name: Set up Python 3.x
         uses: wntrblm/nox@2022.8.7
         with:

--- a/.github/workflows/version-testing.yml
+++ b/.github/workflows/version-testing.yml
@@ -3,7 +3,7 @@ name: Version Testing with Nox
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [ main, development ]
     paths:
       - 'pyproject.toml'
 

--- a/.github/workflows/version-testing.yml
+++ b/.github/workflows/version-testing.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3.x
         uses: wntrblm/nox@2022.8.7
         with:
-          python-versions: "3.8, 3.9, 3.10, 3.11"
+          python-versions: "3.9, 3.10, 3.11"
       - name: Install libegl1
         run: |
           sudo apt-get update


### PR DESCRIPTION
The nox based version testing is failing on the development branch with the error `ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device`. Since the error is persisting, it's worth fixing so we can get the development branch passing.

This PR takes two steps to reduce the space used on the runner:
1) Removes testing of python 3.8, which we no longer support (specified in pyproject.toml and reflected in the docs)
2) Runs the `jlumbroso/free-disk-space@main` workflow which can free up substantial disk space.

Between these changes (primarily 2), we should have passing tests in `development` and will be able to work on merging those changes into main.