### PR TITLE
Fix development runners

### DIFF
--- a/.github/workflows/version-testing.yml
+++ b/.github/workflows/version-testing.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          large-packages: false
+          docker-images: false
+          swap-storage: false
       - name: Set up Python 3.x
         uses: wntrblm/nox@2022.8.7
         with:

--- a/.github/workflows/version-testing.yml
+++ b/.github/workflows/version-testing.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Free up disk space
-        uses: jlumbroso/free-disk-space@main
       - name: Set up Python 3.x
         uses: wntrblm/nox@2022.8.7
         with:


### PR DESCRIPTION
The nox files are failing on development, now with a new issue. It seems the disk freeing action messed with the libegl downloads enough that our current downloading of them wasn't enough to get opencv to run. I'm going to see if removing 3.8 testing freed enough disk space for the tests to run, and if not I'll debug some of the options in the free disk space workflow to see what we can get away with removing.