### PR TITLE
Change multiprocessing parameter options

### DIFF
--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
@@ -42,7 +42,7 @@ RUN_3D_TRIANGULATION_NAME = "Run 3d triangulation?"
 
 RUN_BUTTERWORTH_FILTER_NAME = "Run butterworth filter?"
 
-NUMBER_OF_PROCESSES_PARAMETER_NAME = "Number of Processes to use"
+NUMBER_OF_PROCESSES_PARAMETER_NAME = "Max Number of Processes to Use"
 
 
 def create_mediapipe_parameter_group(

--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/process_motion_capture_data_panel.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/process_motion_capture_data_panel.py
@@ -194,6 +194,7 @@ class ProcessMotionCaptureDataPanel(QWidget):
         parameter = Parameter.create(
             name=NUMBER_OF_PROCESSES_PARAMETER_NAME,
             type="int",
+            limits=(1, multiprocessing.cpu_count() - 1),
             value=(multiprocessing.cpu_count() - 1),
             tip="If your computer has issues processing larger videos, you can try setting number of processes to 1 to process each video serially.",
         )


### PR DESCRIPTION
This will fix #513, once we get consensus on how we want it set up.

Right now, I've changed "Number of Processes to Use" to "Max Number of Processes to Use", to make it more clear that we won't necessarily spin up every process available. I've also added limits to the parameter group, so the user can't select less than 1 process, or more than the number of cores they have available minus one. 

It's possible to implement different naming, i.e. have 1 show up as "1 (no multiprocessing)" or the max show as "MAX" by implementing the parameter as a group and creating a list that the parameter pulls from. Since this would involve some logic and we haven't decided on it, I haven't added it yet.

The same goes for adding a "Use Multiprocessing" bool that supersedes the "Number of Processes" - we can do it, but it will add quite a bit of gui logic depending on how we implement it, so I want to make sure it's the direction we want to go.