### PR TITLE
PATCH: logging to wrong location

### DIFF
--- a/freemocap/system/logging/configure_logging.py
+++ b/freemocap/system/logging/configure_logging.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from logging.config import dictConfig
 
-from skellycam.system.environment.default_paths import get_log_file_path
+from freemocap.system.paths_and_filenames.path_getters import get_log_file_path
 
 # Suppress some annoying log messages
 logging.getLogger("tzlocal").setLevel(logging.WARNING)


### PR DESCRIPTION
Currently, `configure_logging.py` imports the function that gets the path to log to form skellycam instead of freemocap, meaning freemocap logs are logged to the `skelly-cam-recordings` folder instead of the `freemocap_data` folder. This is obviously confusing to users, and makes it ahrder for us to get good log files while providing technical support. 

This PR changes the source of the `get_log_file_path` function from skellycam to freemocap, making logs save to `freemocap_data` again.