### PR TITLE
Log progress indicator

### DIFF
--- a/freemocap/__init__.py
+++ b/freemocap/__init__.py
@@ -11,7 +11,7 @@ __repo_issues_url__ = f"{__repo_url__}issues"
 
 from freemocap.system.logging.configure_logging import configure_logging, LogLevel
 
-configure_logging(LogLevel.INFO)
+configure_logging(LogLevel.DEBUG)
 import logging
 
 logger = logging.getLogger(__name__)

--- a/freemocap/core_processes/post_process_skeleton_data/post_process_skeleton.py
+++ b/freemocap/core_processes/post_process_skeleton_data/post_process_skeleton.py
@@ -19,6 +19,7 @@ from skellyforge.freemocap_utils.postprocessing_widgets.task_worker_thread impor
 
 from freemocap.system.logging.configure_logging import log_view_logging_format_string
 from freemocap.system.logging.queue_logger import DirectQueueHandler
+from freemocap.system.paths_and_filenames.file_and_folder_names import LOG_VIEW_PROGRESS_BAR_STRING
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,7 @@ def run_post_processing_worker(raw_skel3d_frame_marker_xyz: np.ndarray, settings
     post_processed_data_handler = PostProcessedDataHandler()
 
     logger.info("Starting post-processing worker thread")
+    logger.info(LOG_VIEW_PROGRESS_BAR_STRING)
 
     worker_thread = TaskWorkerThread(
         raw_skeleton_data=raw_skel3d_frame_marker_xyz,

--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
@@ -23,7 +23,6 @@ from freemocap.data_layer.data_saver.data_saver import DataSaver
 from freemocap.data_layer.recording_models.post_processing_parameter_models import ProcessingParameterModel
 from freemocap.system.logging.queue_logger import DirectQueueHandler
 from freemocap.system.logging.configure_logging import log_view_logging_format_string
-from freemocap.system.paths_and_filenames.file_and_folder_names import LOG_VIEW_PROGRESS_BAR_STRING
 from freemocap.utilities.geometry.rotate_by_90_degrees_around_x_axis import rotate_by_90_degrees_around_x_axis
 from freemocap.utilities.kill_event_exception import KillEventException
 

--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
@@ -23,6 +23,7 @@ from freemocap.data_layer.data_saver.data_saver import DataSaver
 from freemocap.data_layer.recording_models.post_processing_parameter_models import ProcessingParameterModel
 from freemocap.system.logging.queue_logger import DirectQueueHandler
 from freemocap.system.logging.configure_logging import log_view_logging_format_string
+from freemocap.system.paths_and_filenames.file_and_folder_names import LOG_VIEW_PROGRESS_BAR_STRING
 from freemocap.utilities.geometry.rotate_by_90_degrees_around_x_axis import rotate_by_90_degrees_around_x_axis
 from freemocap.utilities.kill_event_exception import KillEventException
 
@@ -56,8 +57,6 @@ def process_recording_folder(
         handler = DirectQueueHandler(logging_queue)
         handler.setFormatter(logging.Formatter(fmt=log_view_logging_format_string, datefmt="%Y-%m-%dT%H:%M:%S"))
         logger.addHandler(handler)
-
-    logger.info("progress")
 
     try:
         processing_pipeline_check(processing_parameters=recording_processing_parameter_model)

--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
@@ -56,6 +56,9 @@ def process_recording_folder(
         handler = DirectQueueHandler(logging_queue)
         handler.setFormatter(logging.Formatter(fmt=log_view_logging_format_string, datefmt="%Y-%m-%dT%H:%M:%S"))
         logger.addHandler(handler)
+
+    logger.info("progress")
+
     try:
         processing_pipeline_check(processing_parameters=recording_processing_parameter_model)
     except FileNotFoundError as e:

--- a/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/image_tracking_pipeline_functions.py
+++ b/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/image_tracking_pipeline_functions.py
@@ -13,7 +13,7 @@ from freemocap.data_layer.recording_models.post_processing_parameter_models impo
 )
 from freemocap.system.logging.configure_logging import log_view_logging_format_string
 from freemocap.system.logging.queue_logger import DirectQueueHandler
-from freemocap.system.paths_and_filenames.file_and_folder_names import RAW_DATA_FOLDER_NAME
+from freemocap.system.paths_and_filenames.file_and_folder_names import LOG_VIEW_PROGRESS_BAR_STRING, RAW_DATA_FOLDER_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def run_image_tracking_pipeline(
             raise RuntimeError("Failed to load 2D data, cannot continue processing") from e
     else:
         logger.info("Detecting 2d skeletons...")
-        logger.info("progress")
+        logger.info(LOG_VIEW_PROGRESS_BAR_STRING)
         # 2d skeleton detection
         image_data_numCams_numFrames_numTrackedPts_XYZ = run_image_tracking(
             tracking_params=processing_parameters.mediapipe_parameters_model,

--- a/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/image_tracking_pipeline_functions.py
+++ b/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/image_tracking_pipeline_functions.py
@@ -42,6 +42,7 @@ def run_image_tracking_pipeline(
             raise RuntimeError("Failed to load 2D data, cannot continue processing") from e
     else:
         logger.info("Detecting 2d skeletons...")
+        logger.info("progress")
         # 2d skeleton detection
         image_data_numCams_numFrames_numTrackedPts_XYZ = run_image_tracking(
             tracking_params=processing_parameters.mediapipe_parameters_model,

--- a/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/triangulation_pipeline_functions.py
+++ b/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/triangulation_pipeline_functions.py
@@ -13,6 +13,7 @@ from freemocap.core_processes.post_process_skeleton_data.process_single_camera_s
 from freemocap.data_layer.recording_models.post_processing_parameter_models import ProcessingParameterModel
 from freemocap.system.logging.queue_logger import DirectQueueHandler
 from freemocap.system.logging.configure_logging import log_view_logging_format_string
+from freemocap.system.paths_and_filenames.file_and_folder_names import LOG_VIEW_PROGRESS_BAR_STRING
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,7 @@ def get_triangulated_data(
 
     if image_data_numCams_numFrames_numTrackedPts_XYZ.shape[0] == 1:
         logger.info("Skipping 3d triangulation for single camera data")
+        logger.info(LOG_VIEW_PROGRESS_BAR_STRING)
         (raw_skel3d_frame_marker_xyz, skeleton_reprojection_error_fr_mar) = process_single_camera_skeleton_data(
             input_image_data_frame_marker_xyz=image_data_numCams_numFrames_numTrackedPts_XYZ[0],
             raw_data_folder_path=Path(processing_parameters.recording_info_model.raw_data_folder_path),
@@ -38,6 +40,7 @@ def get_triangulated_data(
         logger.info(
             f"Skipping 3d triangulation and loading data from: {processing_parameters.recording_info_model.raw_mediapipe_3d_data_npy_file_path}"
         )
+        logger.info(LOG_VIEW_PROGRESS_BAR_STRING)
         try:
             raw_skel3d_frame_marker_xyz = np.load(
                 processing_parameters.recording_info_model.raw_mediapipe_3d_data_npy_file_path
@@ -50,6 +53,7 @@ def get_triangulated_data(
             raise RuntimeError("Failed to load 3D data, cannot continue processing") from e
     else:
         logger.info("Triangulating 3d skeletons...")
+        logger.info(LOG_VIEW_PROGRESS_BAR_STRING)
 
         if not processing_parameters.recording_info_model.calibration_toml_check:
             raise FileNotFoundError(

--- a/freemocap/gui/qt/widgets/log_view_widget.py
+++ b/freemocap/gui/qt/widgets/log_view_widget.py
@@ -67,6 +67,7 @@ class LogViewWidget(QPlainTextEdit):
         self._logging_queue = multiprocessing.Queue(-1)
         self._queue_handler = QueueHandler(self._logging_queue)
         self._queue_handler.setFormatter(log_view_logging_formatter)
+        self._queue_handler.setLevel(logging.INFO)
         logging.getLogger("").handlers.append(self._queue_handler)
 
         self._exit_event = threading.Event()

--- a/freemocap/system/paths_and_filenames/file_and_folder_names.py
+++ b/freemocap/system/paths_and_filenames/file_and_folder_names.py
@@ -46,6 +46,9 @@ FREEMOCAP_TEST_DATA_RECORDING_NAME = "freemocap_sample_data"
 # logo
 PATH_TO_FREEMOCAP_LOGO_SVG = str(Path(freemocap.__file__).parent / "assets/logo/freemocap-logo-black-border.svg")
 
+# progress bars
+LOG_VIEW_PROGRESS_BAR_STRING = "Log Progress"
+
 # emoji strings
 SPARKLES_EMOJI_STRING = "\U00002728"
 SKULL_EMOJI_STRING = "\U0001F480"


### PR DESCRIPTION
This PR adds a progress indicator to the Log View Widget that shows when processing intensive tasks are in progress. This has been an ask for a while, and the primary motivator is to allow users of the Mac app bundle to see progress, as the app bundle does not allow logging to the terminal.

https://github.com/freemocap/freemocap/assets/24758117/d99c6271-67d9-4a6f-9f51-8fb9ee121faa

Limitations: It only indicates that the process is in progress, not what percentage/amount of the task is done like in a traditional progress bar. This is to limit the data that needs to be sent between processes (and the amount of quite technical code that would need to be replicated to get the progress bars to display correctly).

The other current limitation is it does not log during the blender processing. I intend to do a bit of a deep dive into how we log the blender output, as that is a current painpoint. The main thing that would need to happen is the log_view_widget would have to be passed to the export blender functions. However, currently Blender is blocking the GUI thread, so that would need to be fixed first.