### PR TITLE
Put blender in threadworker

### DIFF
--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/process_motion_capture_data_panel.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/process_motion_capture_data_panel.py
@@ -233,8 +233,11 @@ class ProcessMotionCaptureDataPanel(QWidget):
             session_parameter_model.recording_info_model.calibration_toml_path = selected_camera_calibration_toml_path
 
             # check if there is already a calibration toml  in the recording folder, if not save this one there
-            if len(list(Path(session_parameter_model.recording_info_model.path).glob("*.toml"))) == 0:
-                # copy the calibration toml to the recording folder (keeping the original filename
+            if (
+                len(list(Path(session_parameter_model.recording_info_model.path).glob("*.toml"))) == 0
+                and Path(selected_camera_calibration_toml_path).exists()
+            ):
+                # copy the calibration toml to the recording folder (keeping the original filename)
                 logger.info(
                     f"Copying calibration toml from {selected_camera_calibration_toml_path} to {session_parameter_model.recording_info_model.path}"
                 )

--- a/freemocap/gui/qt/workers/export_to_blender_thread_worker.py
+++ b/freemocap/gui/qt/workers/export_to_blender_thread_worker.py
@@ -1,0 +1,58 @@
+import logging
+import threading
+from pathlib import Path
+
+from PySide6.QtCore import Signal, QThread
+
+from freemocap.core_processes.export_data.blender_stuff.export_to_blender.export_to_blender import export_to_blender
+
+logger = logging.getLogger(__name__)
+
+
+class ExportToBlenderThreadWorker(QThread):
+    finished = Signal()
+    in_progress = Signal(str)
+
+    def __init__(
+        self,
+        recording_path: Path,
+        blender_file_path: Path,
+        blender_executable_path: Path,
+        blender_method: str,
+        kill_thread_event: threading.Event,
+    ):
+        super().__init__()
+        logger.debug("Initializing Export to Blender Thread Worker")
+        self._kill_thread_event = kill_thread_event
+        self.recording_path = recording_path
+        self.blender_file_path = blender_file_path
+        self.blender_executable_path = blender_executable_path
+        self.blender_method = blender_method
+
+        self._work_done = False
+
+    @property
+    def work_done(self):
+        return self._work_done
+
+    def _emit_in_progress_data(self, message: str):
+        self.in_progress.emit(message)
+
+    def run(self):
+        logger.info("Beginning to synchronize videos")
+
+        try:
+            export_to_blender(
+                recording_folder_path=self.recording_path,
+                blender_file_path=self.blender_file_path,
+                blender_exe_path=self.blender_executable_path,
+                method=self.blender_method,
+            )
+        except Exception as e:
+            logger.exception("something went wrong in the Blender export")
+            logger.exception(e)
+
+        self.finished.emit()
+        self._work_done = True
+
+        logger.debug("Blender Export Complete")


### PR DESCRIPTION
This PR switches the Blender subprocesses to run form a threadworker. While `subprocess.Popen` is supposed to be non-blocking, it was blocking the main gui process. This allows the gui to run freely while processing, which is good in itself and also allows us to update the gui with a progress indicator while blender is processing.

The only negative change so far is that when Blender opens, it pops up a "Do you want to save this file?" dialog box, like it is exiting another blender window. Choosing either option seems to work fine. I think it's worth it to not block the gui, but @jonmatthis you might be able to figure out why this is happening.