### PR TITLE
Handle toml load exceptions

### DIFF
--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/get_anipose_calibration_object.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/get_anipose_calibration_object.py
@@ -25,8 +25,8 @@ def load_most_recent_anipose_calibration_toml(save_copy_of_calibration_to_this_p
 
     try:
         camera_group = freemocap_anipose.CameraGroup.load(str(most_recent_calibration_toml_path))
-    except:
-        logger.error(f"Failed to load anipose calibration info from {str(most_recent_calibration_toml_path)}")
+    except Exception as e:
+        logger.exception(e)
         raise
     return camera_group
 

--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/get_anipose_calibration_object.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/get_anipose_calibration_object.py
@@ -23,7 +23,12 @@ def load_most_recent_anipose_calibration_toml(save_copy_of_calibration_to_this_p
             str(Path(save_copy_of_calibration_to_this_path) / Path(most_recent_calibration_toml_path).name),
         )
 
-    return freemocap_anipose.CameraGroup.load(str(most_recent_calibration_toml_path))
+    try:
+        camera_group = freemocap_anipose.CameraGroup.load(str(most_recent_calibration_toml_path))
+    except:
+        logger.error(f"Failed to load anipose calibration info from {str(most_recent_calibration_toml_path)}")
+        raise
+    return camera_group
 
 
 def load_anipose_calibration_toml_from_path(

--- a/freemocap/system/paths_and_filenames/path_getters.py
+++ b/freemocap/system/paths_and_filenames/path_getters.py
@@ -175,7 +175,6 @@ def get_most_recent_recording_path(subfolder_str: str = None):
         logger.exception(e)
         return None
 
-
     if not Path(most_recent_recording_path).exists():
         logger.error(f"Most recent recording path {most_recent_recording_path} not found!!")
         return None

--- a/freemocap/system/paths_and_filenames/path_getters.py
+++ b/freemocap/system/paths_and_filenames/path_getters.py
@@ -168,8 +168,13 @@ def get_most_recent_recording_path(subfolder_str: str = None):
         logger.error(f"{MOST_RECENT_RECORDING_TOML_FILENAME} not found at {get_most_recent_recording_toml_path()}!!")
         return None
 
-    most_recent_recording_dict = toml.load(str(get_most_recent_recording_toml_path()))
-    most_recent_recording_path = most_recent_recording_dict["most_recent_recording_path"]
+    try:
+        most_recent_recording_dict = toml.load(str(get_most_recent_recording_toml_path()))
+        most_recent_recording_path = most_recent_recording_dict["most_recent_recording_path"]
+    except (ValueError, toml.TomlDecodeError, KeyError) as e:
+        logger.exception(e)
+        return None
+
 
     if not Path(most_recent_recording_path).exists():
         logger.error(f"Most recent recording path {most_recent_recording_path} not found!!")


### PR DESCRIPTION
Fixes #532 by handling toml load exceptions. I haven't figured out what escape character was causing the problem in the linked issue, but this exception handling should be robust to different toml problems. 