### PR TITLE
Handle active recording is None

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,6 +14,7 @@ per-file-ignores =
     ./freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py:C901
     ./freemocap/core_processes/detecting_things_in_2d_images/mediapipe_stuff/mediapipe_skeleton_detector.py:C901
     ./freemocap/core_processes/detecting_things_in_2d_images/mediapipe_stuff/convert_mediapipe_npy_to_csv.py:E203
+    ./freemocap/gui/qt/widgets/control_panel/calibration_control_panel.py:C901
     ./experimental/batch_process/batch_process.py:E226
 # C901: function is too complex
 # E203: whitespace before ':' (PEP8 says this doesn't apply to slicing)

--- a/freemocap/gui/qt/main_window/freemocap_main_window.py
+++ b/freemocap/gui/qt/main_window/freemocap_main_window.py
@@ -523,10 +523,11 @@ class MainWindow(QMainWindow):
 
         if self._home_widget.consent_to_send_usage_information:
             self._pipedream_pings.update_pings_dict(key="gui_closed", value=True)
-            self._pipedream_pings.update_pings_dict(
-                key="active recording status on close",
-                value=self._active_recording_info_widget.active_recording_info.status_check,
-            )
+            if self._active_recording_info_widget.active_recording_info is not None:
+                self._pipedream_pings.update_pings_dict(
+                    key="active recording status on close",
+                    value=self._active_recording_info_widget.active_recording_info.status_check,
+                )
             self._pipedream_pings.send_pipedream_ping()
 
         try:

--- a/freemocap/gui/qt/widgets/control_panel/calibration_control_panel.py
+++ b/freemocap/gui/qt/widgets/control_panel/calibration_control_panel.py
@@ -136,6 +136,8 @@ class CalibrationControlPanel(QWidget):
         if self._calibration_toml_path is not None:
             logger.debug(f"Setting calibration TOML path: {self._calibration_toml_path}")
             self._show_selected_calibration_toml_path(self._calibration_toml_path)
+        elif active_recording_info is None:
+            self._show_selected_calibration_toml_path("-No Active Recording-")
         elif active_recording_info.single_video_check:
             self._show_selected_calibration_toml_path("-Single Video Recording, No Calibration Needed-")
         else:


### PR DESCRIPTION
This is a continuation of #537. I was able to find more cases where we assume the active recording info isn't `None`. I'm now able to run a full GUI session starting with no active recording. The impetus for handling this error case better is #532.

The alternative to this checking-for-None approach would be to make sure we always initialize an active recording, even if it isn't complete. That may just move the onus of `None` checking to different fields like `recording_path` though.