### PR TITLE
PATCH: calibration not updating on success

### DIFF
--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
@@ -67,7 +67,7 @@ class AniposeCameraCalibrator:
             dict_size=250,
         )
 
-    def calibrate_camera_capture_volume(self, pin_camera_0_to_origin: bool = False):
+    def calibrate_camera_capture_volume(self, pin_camera_0_to_origin: bool = False) -> Path:
         video_paths_list_of_list_of_strings = [[str(this_path)] for this_path in self._list_of_video_paths]
 
         (
@@ -108,7 +108,11 @@ class AniposeCameraCalibrator:
         logger.debug(
             f"anipose camera calibration data also saved to 'Last Successful Calibration' - {last_successful_calibration_toml_path}"
         )
-        self._progress_callback("Anipose camera calibration data saved to calibrations folder, recording folder, and `Last Successful Calibration` file")
+        self._progress_callback(
+            "Anipose camera calibration data saved to calibrations folder, recording folder, and `Last Successful Calibration` file"
+        )
+
+        return calibration_folder_toml_path
 
     def pin_camera_zero_to_origin(self, _anipose_camera_group_object):
         original_translation_vectors = _anipose_camera_group_object.get_translations()

--- a/freemocap/core_processes/capture_volume_calibration/run_anipose_capture_volume_calibration.py
+++ b/freemocap/core_processes/capture_volume_calibration/run_anipose_capture_volume_calibration.py
@@ -19,11 +19,13 @@ def run_anipose_capture_volume_calibration(
     calibration_videos_folder_path: Union[str, Path],
     pin_camera_0_to_origin: bool = True,
     progress_callback: Callable[[str], None] = None,
-):
+) -> Path:
     anipose_camera_calibrator = AniposeCameraCalibrator(
         charuco_board_definition,
         charuco_square_size=charuco_square_size,
         calibration_videos_folder_path=calibration_videos_folder_path,
         progress_callback=progress_callback,
     )
-    anipose_camera_calibrator.calibrate_camera_capture_volume(pin_camera_0_to_origin=pin_camera_0_to_origin)
+    toml_path = anipose_camera_calibrator.calibrate_camera_capture_volume(pin_camera_0_to_origin=pin_camera_0_to_origin)
+
+    return toml_path

--- a/freemocap/gui/qt/workers/anipose_calibration_thread_worker.py
+++ b/freemocap/gui/qt/workers/anipose_calibration_thread_worker.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class AniposeCalibrationThreadWorker(QThread):
-    finished = Signal()
+    finished = Signal(str)
     in_progress = Signal(str)
 
     def __init__(
@@ -51,19 +51,19 @@ class AniposeCalibrationThreadWorker(QThread):
         logger.info("Beginning Anipose calibration with Charuco Square Size (mm): {}".format(self._charuco_square_size))
 
         try:
-            run_anipose_capture_volume_calibration(
+            toml_path = run_anipose_capture_volume_calibration(
                 charuco_board_definition=self._charuco_board_definition,
                 charuco_square_size=self._charuco_square_size,
                 calibration_videos_folder_path=self._calibration_videos_folder_path,
                 pin_camera_0_to_origin=True,
                 progress_callback=self._emit_in_progress_data,
             )
+            self.finished.emit(str(toml_path))
 
         except Exception as e:
             logger.exception("something went wrong in the anipose calibration")
             logger.exception(e)
 
-        self.finished.emit()
         self._work_done = True
 
         logger.info("Anipose Calibration Complete")


### PR DESCRIPTION
The calibration path is not being set properly after a successful calibration. This PR passes the calibration path explicitly into the `update_calibration_toml_path` function to bypass the control logic when `None` is passed in.

Right now, its set so the path is set to the toml path from the calibrations folder, but we can change that to the recording folder toml or the most recent calibration toml, whichever is best.