### PR TITLE
Patch runners and mediapipe

### DIFF
--- a/.github/workflows/coverage-testing.yml
+++ b/.github/workflows/coverage-testing.yml
@@ -1,11 +1,11 @@
-name: Version Testing with Nox
+name: Coverage with Nox
 
 on:
   workflow_dispatch:
   pull_request:
     branches: [ main, development ]
     paths:
-      - 'pyproject.toml'
+        - 'freemocap/**'
 
 jobs:
   build:
@@ -28,4 +28,4 @@ jobs:
           sudo apt-get install libegl1-mesa
       - name: Run noxfile
         run: |
-          nox --session test
+          nox --session coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "skellyforge==2023.12.1005",
     "skelly_synchronize==2023.12.1029",
     "ajc27_freemocap_blender_addon==2023.10.1016",
-    "mediapipe~=0.10.0",
+    "mediapipe==0.10.9",
     "opencv-contrib-python==4.8.*",
     "toml==0.10.2",
     "aniposelib==0.4.3",


### PR DESCRIPTION
This PR does two things:
- Pin mediapipe to the working 0.10.9 version, since 10.10 isn't working on either architecture mac
- Split the coverage testing into a separate github action from version testing. This reduces the memory load on the runners, which keep failing with memory errors. It also allows us to run the faster coverage testing more often, which might encourage us to *write more tests*!