### PR TITLE
Add YOLO Crop Parameters to Parameter Tree

### DIFF
--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from pyqtgraph.parametertree import Parameter
 from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
     MediapipeTrackingParams,
@@ -32,7 +33,13 @@ MINIMUM_CAMERAS_TO_REPROJECT = "Minimum Cameras to Reproject"
 
 ANIPOSE_TREE_NAME = "Anipose Triangulation"
 
+YOLO_CROP_TREE_NAME = "YOLO Crop"
+
 USE_YOLO_CROP_METHOD = "Use YOLO Crop Method"
+
+BOUNDING_BOX_BUFFER_METHOD = "Buffer Bounding Box:"
+
+BOUNDING_BOX_BUFFER_PERCENTAGE = "Bounding Box Buffer Percentage"
 
 STATIC_IMAGE_MODE = "Static Image Mode"
 
@@ -66,10 +73,31 @@ def create_mediapipe_parameter_group(
         type="group",
         children=[
             dict(
-                name=USE_YOLO_CROP_METHOD,
-                type="bool",
-                value=parameter_model.use_yolo_crop_method,
-                tip="If true, `skellytracker` will use YOLO to pre-crop the person from the image before running the `mediapipe` tracker",
+                name=YOLO_CROP_TREE_NAME,
+                type="group",
+                children=[
+                    dict(
+                        name=USE_YOLO_CROP_METHOD,
+                        type="bool",
+                        value=parameter_model.use_yolo_crop_method,
+                        tip="If true, `skellytracker` will use YOLO to pre-crop the person from the image before running the `mediapipe` tracker",
+                    ),
+                    dict(
+                        name=BOUNDING_BOX_BUFFER_METHOD,
+                        type="list",
+                        limits=["By box size", "By image size"],
+                        value=parameter_model.buffer_size_method,
+                        tip="Buffer bounding box by percentage of either box size or image size",
+                    ),
+                    dict(
+                        name=BOUNDING_BOX_BUFFER_PERCENTAGE,
+                        type="int",
+                        value=parameter_model.bounding_box_buffer_percentage,
+                        limits=(0, 100),
+                        step=1,
+                        tip="Percentage to increase size of bounding box",
+                    ),
+                ],
             ),
             dict(
                 name=MEDIAPIPE_MODEL_COMPLEXITY,
@@ -213,6 +241,10 @@ def extract_parameter_model_from_parameter_tree(
             run_image_tracking=parameter_values_dictionary[RUN_IMAGE_TRACKING_NAME],
             num_processes=parameter_values_dictionary[NUMBER_OF_PROCESSES_PARAMETER_NAME],
             use_yolo_crop_method=parameter_values_dictionary[USE_YOLO_CROP_METHOD],
+            buffer_size_method=get_bounding_box_buffer_method_from_string(
+                parameter_values_dictionary[BOUNDING_BOX_BUFFER_METHOD]
+            ),
+            bounding_box_buffer_percentage=parameter_values_dictionary[BOUNDING_BOX_BUFFER_PERCENTAGE],
         ),
         anipose_triangulate_3d_parameters_model=AniposeTriangulate3DParametersModel(
             run_reprojection_error_filtering=parameter_values_dictionary[RUN_REPROJECTION_ERROR_FILTERING],
@@ -241,6 +273,14 @@ def get_integer_from_mediapipe_model_complexity(mediapipe_model_complexity_value
         "2 (Slowest/Most accurate)": 2,
     }
     return mediapipe_model_complexity_dictionary[mediapipe_model_complexity_value]
+
+
+def get_bounding_box_buffer_method_from_string(buffer_method_string: str) -> str:
+    bounding_box_buffer_method_dict = {
+        "By box size": "buffer_by_box_size",
+        "By image size": "buffer_by_image_size",
+    }
+    return bounding_box_buffer_method_dict[buffer_method_string]
 
 
 def extract_processing_parameter_model_from_tree(parameter_object, value_dictionary: dict = None):

--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
@@ -1,4 +1,3 @@
-from typing import Literal
 from pyqtgraph.parametertree import Parameter
 from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
     MediapipeTrackingParams,

--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
@@ -37,6 +37,8 @@ YOLO_CROP_TREE_NAME = "YOLO Crop"
 
 USE_YOLO_CROP_METHOD = "Use YOLO Crop Method"
 
+YOLO_MODEL_SIZE = "YOLO Model Size"
+
 BOUNDING_BOX_BUFFER_METHOD = "Buffer Bounding Box:"
 
 BOUNDING_BOX_BUFFER_PERCENTAGE = "Bounding Box Buffer Percentage"
@@ -81,6 +83,13 @@ def create_mediapipe_parameter_group(
                         type="bool",
                         value=parameter_model.use_yolo_crop_method,
                         tip="If true, `skellytracker` will use YOLO to pre-crop the person from the image before running the `mediapipe` tracker",
+                    ),
+                    dict(
+                        name=YOLO_MODEL_SIZE,
+                        type="list",
+                        limits=["nano", "small", "medium", "large", "extra_large", "high_res"],
+                        value=parameter_model.yolo_model_size,
+                        tip="Smaller models are faster but may be less accurate",
                     ),
                     dict(
                         name=BOUNDING_BOX_BUFFER_METHOD,
@@ -241,6 +250,7 @@ def extract_parameter_model_from_parameter_tree(
             run_image_tracking=parameter_values_dictionary[RUN_IMAGE_TRACKING_NAME],
             num_processes=parameter_values_dictionary[NUMBER_OF_PROCESSES_PARAMETER_NAME],
             use_yolo_crop_method=parameter_values_dictionary[USE_YOLO_CROP_METHOD],
+            yolo_model_size=parameter_values_dictionary[YOLO_MODEL_SIZE],
             buffer_size_method=get_bounding_box_buffer_method_from_string(
                 parameter_values_dictionary[BOUNDING_BOX_BUFFER_METHOD]
             ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "ipykernel==6.23.1",
     "plotly==5.14.1",
     "pydantic==1.*",
-    "skellytracker==2024.3.1011",
+    "skellytracker==2024.3.1012",
     "PySide6==6.6.*",
     "packaging===23.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "ipykernel==6.23.1",
     "plotly==5.14.1",
     "pydantic==1.*",
-    "skellytracker==2024.3.1012",
+    "skellytracker==2024.03.1013",
     "PySide6==6.6.*",
     "packaging===23.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "ipykernel==6.23.1",
     "plotly==5.14.1",
     "pydantic==1.*",
-    "skellytracker==2024.3.1009",
+    "skellytracker==2024.3.1011",
     "PySide6==6.6.*",
     "packaging===23.2",
 ]


### PR DESCRIPTION
Parameterizes the YOLO crop method with model size, bounding box buffer method, and bounding box size. This will give the user more control over the process.

In the gui, it looks like this, with the entire yolo crop section being collapsible
<img width="478" alt="Screen Shot 2024-03-20 at 4 02 55 PM" src="https://github.com/freemocap/freemocap/assets/24758117/2de428d2-dd82-4a9b-85b7-a0f96c37257f">
