### PR TITLE
Patch: Fix link in welcome screen

### DIFF
--- a/freemocap/gui/qt/widgets/welcome_screen_dialog.py
+++ b/freemocap/gui/qt/widgets/welcome_screen_dialog.py
@@ -48,7 +48,7 @@ class WelcomeScreenDialog(QDialog):
         multi_camera_docs_label.setWordWrap(True)
         self._layout.addWidget(multi_camera_docs_label, 1)
 
-        multi_camera_recording_doc_link_string = '&#10132; <a href="https://freemocap.github.io/documentation/multi-camera-calibration.html</a>'
+        multi_camera_recording_doc_link_string = '&#10132; <a href="https://freemocap.github.io/documentation/multi-camera-calibration.html" style="color: #333333;"> Multi camera recording tutorial</a>'
         multi_camera_doc_link = QLabel(multi_camera_recording_doc_link_string)
         multi_camera_doc_link.setOpenExternalLinks(True)
         self._layout.addWidget(multi_camera_doc_link)


### PR DESCRIPTION
Finishes the html in the multi camera tutorial link on the welcome screen.


The problem is shown here:
<img width="710" alt="Screen Shot 2024-03-26 at 2 07 38 PM" src="https://github.com/freemocap/freemocap/assets/24758117/be57d130-c49d-4c5b-9ddc-f8678c84c8e5">
