### PR TITLE
Catch blender errors

### DIFF
--- a/freemocap/core_processes/export_data/blender_stuff/export_to_blender/methods/ajc_addon/run_ajc_addon_main.py
+++ b/freemocap/core_processes/export_data/blender_stuff/export_to_blender/methods/ajc_addon/run_ajc_addon_main.py
@@ -39,7 +39,6 @@ def run_ajc_blender_addon_subprocess(
     try:
         ajc_blender_addon_validator(recording_folder_path=recording_folder_path)
     except FileNotFoundError as e:
-        logger.error(e)
         logger.error("Missing required files to run AJC addon, did something go wrong during processing?")
         raise e
 
@@ -142,6 +141,13 @@ def ajc_blender_addon_validator(recording_folder_path: Union[str, Path]):
     if not (output_data_path / "center_of_mass" / "segmentCOM_frame_joint_xyz.npy").exists():
         raise FileNotFoundError(
             f"Could not find required file: {output_data_path / 'center_of_mass' / 'segmentCOM_frame_joint_xyz.npy'}"
+        )
+
+    if not (
+        output_data_path / "raw_data" / "mediapipe3dData_numFrames_numTrackedPoints_reprojectionError.npy"
+    ).exists():
+        raise FileNotFoundError(
+            f"Could not find required file: {output_data_path / 'raw_data' / 'mediapipe3dData_numFrames_numTrackedPoints_reprojectionError.npy'}"
         )
 
 

--- a/freemocap/core_processes/export_data/blender_stuff/export_to_blender/methods/ajc_addon/run_ajc_addon_main.py
+++ b/freemocap/core_processes/export_data/blender_stuff/export_to_blender/methods/ajc_addon/run_ajc_addon_main.py
@@ -36,6 +36,13 @@ def run_ajc_blender_addon_subprocess(
     blender_file_path: Union[str, Path],
     blender_exe_path: Union[str, Path],
 ):
+    try:
+        ajc_blender_addon_validator(recording_folder_path=recording_folder_path)
+    except FileNotFoundError as e:
+        logger.error(e)
+        logger.error("Missing required files to run AJC addon, did something go wrong during processing?")
+        raise e
+
     ajc_addon_main_file_path = inspect.getfile(ajc27_run_as_main_function)
     logger.debug(f"Running ajc27_freemocap_blender_addon as a subprocess using script at : {ajc_addon_main_file_path}")
 
@@ -51,7 +58,8 @@ def run_ajc_blender_addon_subprocess(
             raise FileNotFoundError(f"Could not find the blender executable at {blender_exe_path}")
     except Exception as e:
         logger.error(e)
-        return
+        raise e
+
     simple_run_script = inspect.getfile(run_simple)
 
     command_list = [
@@ -105,6 +113,36 @@ def get_blenders_numpy(blender_exe_path: Union[str, Path]) -> str:
         raise FileNotFoundError(f"Could not find Blender's numpy at {numpy_path}")
     logger.info(f"Got Blender's numpy path: {numpy_path}")
     return numpy_path
+
+
+def ajc_blender_addon_validator(recording_folder_path: Union[str, Path]):
+    """
+    Check if the required files exist in the recording folder
+    """
+    recording_path = Path(recording_folder_path)
+    output_data_path = recording_path / "output_data"
+
+    if not (output_data_path / "mediapipe_body_3d_xyz.npy").exists():
+        raise FileNotFoundError(f"Could not find required file: {output_data_path / 'mediapipe_body_3d_xyz.npy'}")
+
+    if not (output_data_path / "mediapipe_right_hand_3d_xyz.npy").exists():
+        raise FileNotFoundError(f"Could not find required file: {output_data_path / 'mediapipe_right_hand_3d_xyz.npy'}")
+
+    if not (output_data_path / "mediapipe_left_hand_3d_xyz.npy").exists():
+        raise FileNotFoundError(f"Could not find required file: {output_data_path / 'mediapipe_left_hand_3d_xyz.npy'}")
+
+    if not (output_data_path / "mediapipe_face_3d_xyz.npy").exists():
+        raise FileNotFoundError(f"Could not find required file: {output_data_path / 'mediapipe_face_3d_xyz.npy'}")
+
+    if not (output_data_path / "center_of_mass" / "total_body_center_of_mass_xyz.npy").exists():
+        raise FileNotFoundError(
+            f"Could not find required file: {output_data_path / 'center_of_mass' / 'total_body_center_of_mass_xyz.npy'}"
+        )
+
+    if not (output_data_path / "center_of_mass" / "segmentCOM_frame_joint_xyz.npy").exists():
+        raise FileNotFoundError(
+            f"Could not find required file: {output_data_path / 'center_of_mass' / 'segmentCOM_frame_joint_xyz.npy'}"
+        )
 
 
 if __name__ == "__main__":

--- a/freemocap/gui/qt/main_window/freemocap_main_window.py
+++ b/freemocap/gui/qt/main_window/freemocap_main_window.py
@@ -310,12 +310,12 @@ class MainWindow(QMainWindow):
             kill_thread_event=self._kill_thread_event,
         )
         self._export_to_blender_thread_worker.start()
-        self._export_to_blender_thread_worker.finished.connect(self._handle_export_to_blender_finished)
+        self._export_to_blender_thread_worker.success.connect(self._handle_export_to_blender_finished)
 
     def _handle_export_to_blender_finished(self) -> None:
-        if (
-            self._controller_group_box.auto_open_in_blender_checked
-        ):
+        if self._export_to_blender_thread_worker.success is False:
+            logger.error("Blender export failed!")
+        elif self._controller_group_box.auto_open_in_blender_checked:
             if Path(self._active_recording_info_widget.active_recording_info.blender_file_path).exists():
                 open_file(self._active_recording_info_widget.active_recording_info.blender_file_path)
             else:
@@ -356,7 +356,9 @@ class MainWindow(QMainWindow):
 
         try:
             self._process_motion_capture_data_panel.update_calibration_path()
-        except AttributeError:  # Active Recording and Data Panel widgets rely on each other, so we're guaranteed to hit this every time the app opens
+        except (
+            AttributeError
+        ):  # Active Recording and Data Panel widgets rely on each other, so we're guaranteed to hit this every time the app opens
             logger.debug("Process motion capture data panel not created yet, skipping claibraiton setting")
         except Exception as e:
             logger.error(e)

--- a/freemocap/gui/qt/main_window/freemocap_main_window.py
+++ b/freemocap/gui/qt/main_window/freemocap_main_window.py
@@ -312,8 +312,9 @@ class MainWindow(QMainWindow):
         self._export_to_blender_thread_worker.start()
         self._export_to_blender_thread_worker.success.connect(self._handle_export_to_blender_finished)
 
-    def _handle_export_to_blender_finished(self) -> None:
-        if self._export_to_blender_thread_worker.success is False:
+    @Slot()
+    def _handle_export_to_blender_finished(self, success_value: bool) -> None:
+        if success_value is False:
             logger.error("Blender export failed!")
         elif self._controller_group_box.auto_open_in_blender_checked:
             if Path(self._active_recording_info_widget.active_recording_info.blender_file_path).exists():

--- a/freemocap/gui/qt/workers/export_to_blender_thread_worker.py
+++ b/freemocap/gui/qt/workers/export_to_blender_thread_worker.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExportToBlenderThreadWorker(QThread):
-    finished = Signal()
+    success = Signal(bool)
     in_progress = Signal(str)
 
     def __init__(
@@ -51,8 +51,9 @@ class ExportToBlenderThreadWorker(QThread):
         except Exception as e:
             logger.exception("something went wrong in the Blender export")
             logger.exception(e)
+            self.success.emit(False)
 
-        self.finished.emit()
+        self.success.emit(True)
         self._work_done = True
 
         logger.debug("Blender Export Complete")

--- a/freemocap/gui/qt/workers/export_to_blender_thread_worker.py
+++ b/freemocap/gui/qt/workers/export_to_blender_thread_worker.py
@@ -48,12 +48,11 @@ class ExportToBlenderThreadWorker(QThread):
                 blender_exe_path=self.blender_executable_path,
                 method=self.blender_method,
             )
+            self.success.emit(True)
+            logger.debug("Blender Export Complete")
         except Exception as e:
             logger.exception("something went wrong in the Blender export")
-            logger.exception(e)
+            logger.error(e)
             self.success.emit(False)
 
-        self.success.emit(True)
         self._work_done = True
-
-        logger.debug("Blender Export Complete")


### PR DESCRIPTION
This PR adds a validator to the start of the `run_ajc_addon_main` function to make sure every file referred to in the addon exists before starting the addon. If the requisite files do not exist, it raises a descriptive `FileNotFound` error. 

It also changes the empty `finished` signal to a bool `success` signal, and does not open the Blender file if the blender processing is unsuccessful. This prevents the issue where you re-export to blender, the new export fails, but you're still shown the old blender file because the file exists.

Finally, it changes when tracebacks are logged to prevent logging the same blender error traceback repeatedly, which also helps the most descriptive error show last in the log view widget.