### PR TITLE
Update sample and test data

### DIFF
--- a/freemocap/gui/qt/workers/download_sample_data_thread_worker.py
+++ b/freemocap/gui/qt/workers/download_sample_data_thread_worker.py
@@ -31,5 +31,5 @@ class DownloadDataThreadWorker(QThread):
 
         except Exception as e:  # noqa
             logger.exception(e)
-            logger.error(f"Error downloading sample data from {self._dowload_url}")
+            logger.error(f"Error downloading sample data from {self.download_url}")
             raise e

--- a/freemocap/system/paths_and_filenames/file_and_folder_names.py
+++ b/freemocap/system/paths_and_filenames/file_and_folder_names.py
@@ -44,9 +44,10 @@ SEGMENT_CENTER_OF_MASS_NPY_FILE_NAME = "segmentCOM_frame_joint_xyz.npy"
 RECORDING_PARAMETERS_JSON_FILE_NAME = "recording_parameters.json"
 
 # Figshare info
-FIGSHARE_SAMPLE_ZIP_FILE_URL = "https://figshare.com/ndownloader/files/41368323"
-FIGSHARE_TEST_ZIP_FILE_URL = "https://figshare.com/ndownloader/files/40293973"
-FREEMOCAP_TEST_DATA_RECORDING_NAME = "freemocap_sample_data"
+FIGSHARE_SAMPLE_ZIP_FILE_URL = "https://figshare.com/ndownloader/files/45797067"
+FIGSHARE_TEST_ZIP_FILE_URL = "https://figshare.com/ndownloader/files/45797073"
+FREEMOCAP_TEST_DATA_RECORDING_NAME = "freemocap_test_data"
+FREEMOCAP_SAMPLE_DATA_RECORDING_NAME = "freemocap_sample_data"
 
 # logo
 PATH_TO_FREEMOCAP_LOGO_SVG = str(Path(freemocap.__file__).parent / "assets/logo/freemocap-logo-black-border.svg")

--- a/freemocap/utilities/download_sample_data.py
+++ b/freemocap/utilities/download_sample_data.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import requests
 
 from freemocap.system.paths_and_filenames.file_and_folder_names import (
+    FIGSHARE_SAMPLE_ZIP_FILE_URL,
+    FREEMOCAP_SAMPLE_DATA_RECORDING_NAME,
     FREEMOCAP_TEST_DATA_RECORDING_NAME,
     FIGSHARE_TEST_ZIP_FILE_URL,
 )
@@ -38,7 +40,12 @@ def download_sample_data(sample_data_zip_file_url: str = FIGSHARE_TEST_ZIP_FILE_
         z = zipfile.ZipFile(io.BytesIO(r.content))
         z.extractall(recording_session_folder_path)
 
-        figshare_sample_data_path = recording_session_folder_path / FREEMOCAP_TEST_DATA_RECORDING_NAME
+        if sample_data_zip_file_url == FIGSHARE_TEST_ZIP_FILE_URL:
+            figshare_sample_data_path = recording_session_folder_path / FREEMOCAP_TEST_DATA_RECORDING_NAME
+        elif sample_data_zip_file_url == FIGSHARE_SAMPLE_ZIP_FILE_URL:
+            figshare_sample_data_path = recording_session_folder_path / FREEMOCAP_SAMPLE_DATA_RECORDING_NAME
+        else:
+            figshare_sample_data_path = recording_session_folder_path / "unknown_sample_data"
         logger.info(f"Sample data extracted to {str(figshare_sample_data_path)}")
         return str(figshare_sample_data_path)
 


### PR DESCRIPTION
This PR updates the sample and test data with new figshare links. The videos are the same, but the calibration has been rerun from the sample data, and gives better results than the original calibration we're currently including. It also adds functionality to download the sample data and test data into different folders, so both can be downloaded with overwriting each other (they both would download to `freemocap_sample_data` before). Finally, it fixes a name error in the error logging of the DownloadSampleDataThreadworker.

## To Test:
Switch to this branch, and select `download sample data` from the menu bar, and:
1) make sure it downloads successfully
2) make sure it is correctly set as the active recording
3) make sure it points to a calibration called `freemocap_sample_data_camera_calibration.toml`
4) For bonus points, process the data!
5) Repeat steps 1 through 4, but after selecting `download test data`

All of the above work properly on my machine.

Sample data before:
<img width="631" alt="CurrentSampleDataOutput" src="https://github.com/freemocap/freemocap/assets/24758117/5d2d2b8b-be36-4dcc-a0d5-641f2c9f00b9">
Sample data with updated calibration:
<img width="664" alt="NewCalibrationSampleDataOutput" src="https://github.com/freemocap/freemocap/assets/24758117/13b3a5c4-b991-4a32-98f0-ecdf778ee16f">
