### PR TITLE
Update subrepos to latest versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,11 @@ keywords = [
 
 dependencies = [
     "skellycam==2023.12.1090",
-    "skelly_viewer==2024.03.1021",
+    "skelly_viewer==2024.04.1022",
     "skellyforge==2023.12.1005",
     "skelly_synchronize==2023.12.1029",
-    "ajc27_freemocap_blender_addon==2023.10.1016",
-    "mediapipe==0.10.9",
+    "skellytracker[all]==2024.04.1014",
+    "ajc27_freemocap_blender_addon==2023.10.1017",
     "opencv-contrib-python==4.8.*",
     "toml==0.10.2",
     "aniposelib==0.4.3",
@@ -80,7 +80,6 @@ dependencies = [
     "ipykernel==6.23.1",
     "plotly==5.14.1",
     "pydantic==1.*",
-    "skellytracker==2024.03.1013",
     "PySide6==6.6.*",
     "packaging===23.2",
 ]


### PR DESCRIPTION
This PR brings in the most recent subrepo updates by specifying new versions in `pyproject.toml`.

It adds:
- Finding annotated videos first in skellyviewer
- Fixing default output and enabling rigify automatically in the blender addon
- Latest skellytracker (no specific update for freemocap, just a move of dependencies to extras)