### PR TITLE
Patch: check for OSerror when accessing drives

### DIFF
--- a/freemocap/core_processes/export_data/blender_stuff/get_best_guess_of_blender_path.py
+++ b/freemocap/core_processes/export_data/blender_stuff/get_best_guess_of_blender_path.py
@@ -8,7 +8,11 @@ logger = logging.getLogger(__name__)
 
 def guess_blender_exe_path_from_path(base_path: Union[str, Path]) -> Optional[Path]:
     base_path = Path(base_path)
-    blender_folder_paths = [path for path in base_path.rglob("blender.exe")]
+    try:
+        blender_folder_paths = [path for path in base_path.rglob("blender.exe")]
+    except OSError:
+        logger.info(f"Unable to access: {str(base_path)}")
+        return
 
     if blender_folder_paths:
 


### PR DESCRIPTION
Fixes #581. Checks for an OSerror when running `rglob` on a path. If `rglob` throws an OSerror it will return None, which will be handled by the outer `get_best_guess_of_blender_path()` function.