### PR TITLE
Patch 'export_to_blender' import in batch process

### DIFF
--- a/experimental/batch_process/batch_process.py
+++ b/experimental/batch_process/batch_process.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import Optional, Union
 
-from freemocap.core_processes.export_data.blender_stuff.export_to_blender import export_to_blender
+from freemocap.core_processes.export_data.blender_stuff.export_to_blender.export_to_blender import export_to_blender
 from freemocap.core_processes.process_motion_capture_videos.process_recording_folder import process_recording_folder
 from freemocap.data_layer.recording_models.post_processing_parameter_models import ProcessingParameterModel
 from freemocap.data_layer.recording_models.recording_info_model import RecordingInfoModel


### PR DESCRIPTION
The "export_to_blender" that was imported was the module, not the function in the module, causing an error with the Blender export in the batch processing script. This PR is a small patch to fix the import to the function instead of the module.