### PR TITLE
Add manual instructions to OpenCV conflict dialog

### DIFF
--- a/freemocap/gui/qt/widgets/opencv_conflict_dialog.py
+++ b/freemocap/gui/qt/widgets/opencv_conflict_dialog.py
@@ -30,7 +30,8 @@ class OpencvConflictDialog(QDialog):
             "Choosing `Fix OpenCV version conflict` will remove the existing OpenCV versions and install opencv-contrib-python. "
             "It will also close Freemocap to make the changes take affect, but everything will work when restarted. \n\n"
             "If you choose not to fix the conflict, you will need to manually install opencv-contrib-python and restart Freemocap "
-            "in order for multi-camera calibration to work.\n\n"
+            "in order for multi-camera calibration to work.\n\n To manually fix the conflict, close Freemocap and run `pip uninstall opencv-python opencv-contrib-python` "
+            "followed by `pip install opencv-contrib-python==4.8.1.78`. Then restart Freemocap.\n\n"
         )
         welcome_text_label = QLabel(version_conflict_message)
         welcome_text_label.setWordWrap(True)


### PR DESCRIPTION
The opencv conflict fix fails relatively often. Adding the instructions for a manual fix will help reduce the amount of support we provide in the discord, and ensure users who cannot perform the automated fix have an easy path to success.

I'm open to feedback on where/how we include these instructions, but I do think they should be available in the conflict dialog. 

<img width="694" alt="Screen Shot 2024-05-07 at 11 39 41 AM" src="https://github.com/freemocap/freemocap/assets/24758117/c8224340-cbd8-43ee-8061-1babaa2a6342">
