### PR TITLE
Minor: Fix message at beginning of Blender Export

### DIFF
--- a/freemocap/gui/qt/workers/export_to_blender_thread_worker.py
+++ b/freemocap/gui/qt/workers/export_to_blender_thread_worker.py
@@ -37,7 +37,7 @@ class ExportToBlenderThreadWorker(QThread):
         self.in_progress.emit(message)
 
     def run(self):
-        logger.info("Beginning to synchronize videos")
+        logger.info("Beginning to export to Blender")
 
         try:
             export_to_blender(


### PR DESCRIPTION
At the beginning of the Blender export, it says "beginning to synchronize videos", which is inaccurate. This patches it to say "Beginning to export to Blender" instead