### PR TITLE
Allow PySide 6.7 in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "ipykernel==6.23.1",
     "plotly==5.14.1",
     "pydantic==1.*",
-    "PySide6==6.6.*",
+    "PySide6>=6.6, <6.8",
     "packaging===23.2",
 ]
 


### PR DESCRIPTION
PySide6 is now on version 6.7, and clicking through the GUI it appears no breaking changes have been made. This PR updates `pyproject.toml` so it allows both 6.6 and 6.7.

## To Test
`pip install git+https://github.com/freemocap/freemocap/@philip/update_qt_version` and play around in the GUI, clicking as much as possible