### PR TITLE
Update PyApp Installers

### DIFF
--- a/.github/workflows/linux_installer.yml
+++ b/.github/workflows/linux_installer.yml
@@ -55,7 +55,7 @@ jobs:
           cd ${{ github.workspace }}
           mv ${{ github.workspace }}/bin/pyapp freemocap_app && chmod +x freemocap_app
           tar -czvf freemocap_app.tar.gz freemocap_app
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: freemocap_linux_app
           path: freemocap_app.tar.gz

--- a/.github/workflows/linux_installer.yml
+++ b/.github/workflows/linux_installer.yml
@@ -57,5 +57,5 @@ jobs:
           tar -czvf freemocap_app.tar.gz freemocap_app
       - uses: actions/upload-artifact@v3
         with:
-          name: freemocap
+          name: freemocap_linux_app
           path: freemocap_app.tar.gz

--- a/.github/workflows/linux_installer.yml
+++ b/.github/workflows/linux_installer.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: System Info
         run: |
           uname -a || true

--- a/.github/workflows/linux_installer.yml
+++ b/.github/workflows/linux_installer.yml
@@ -36,18 +36,20 @@ jobs:
           sed '/opencv-python/d' requirements.txt > tmp && mv tmp requirements.txt
       - name: Download PyApp
         run: |
-          curl -L -o pyapp.zip "https://github.com/ofek/pyapp/releases/download/v0.12.0/source.zip"
+          curl -L -o pyapp.zip "https://github.com/ofek/pyapp/releases/download/v0.22.0/source.zip"
       - name: Unzip PyApp
         run: |
           unzip pyapp.zip
       - name: Create Linux Installer
         run: |
-          cd ${{ github.workspace }}/pyapp-v0.12.0
+          cd ${{ github.workspace }}/pyapp-v0.22.0
           export PYAPP_PROJECT_NAME=freemocap
           export PYAPP_PROJECT_VERSION=v1.2.2
+          export PYAPP_PYTHON_VERSION=3.11
           export PYAPP_PROJECT_DEPENDENCY_FILE=${{ github.workspace }}/requirements.txt
           export PYAPP_EXEC_SCRIPT=${{ github.workspace }}/freemocap/__main__.py
           export PYAPP_PIP_EXTRA_ARGS=--no-deps
+          export PYAPP_EXPOSE_ALL_COMMANDS=true
           cargo build --release
           cargo install pyapp --force --root ${{ github.workspace }}
           cd ${{ github.workspace }}

--- a/.github/workflows/mac_installer.yml
+++ b/.github/workflows/mac_installer.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - name: System Info

--- a/.github/workflows/mac_installer.yml
+++ b/.github/workflows/mac_installer.yml
@@ -35,18 +35,20 @@ jobs:
           sed '/opencv-python/d' requirements.txt > tmp && mv tmp requirements.txt
       - name: Download PyApp
         run: |
-          curl -L -o pyapp.zip "https://github.com/ofek/pyapp/releases/download/v0.12.0/source.zip"
+          curl -L -o pyapp.zip "https://github.com/ofek/pyapp/releases/download/v0.22.0/source.zip"
       - name: Unzip PyApp
         run: |
           unzip pyapp.zip
       - name: Create Mac Installer
         run: |
-          cd ${{ github.workspace }}/pyapp-v0.12.0
+          cd ${{ github.workspace }}/pyapp-v0.22.0
           export PYAPP_PROJECT_NAME=freemocap
           export PYAPP_PROJECT_VERSION=v1.2.2
+          export PYAPP_PYTHON_VERSION=3.11
           export PYAPP_PROJECT_DEPENDENCY_FILE=${{ github.workspace }}/requirements.txt
           export PYAPP_EXEC_SCRIPT=${{ github.workspace }}/freemocap/__main__.py
           export PYAPP_PIP_EXTRA_ARGS=--no-deps
+          export PYAPP_EXPOSE_ALL_COMMANDS=true
           cargo build --release
           cargo install pyapp --force --root ${{ github.workspace }}
           cd ${{ github.workspace }}

--- a/.github/workflows/mac_installer.yml
+++ b/.github/workflows/mac_installer.yml
@@ -62,7 +62,7 @@ jobs:
           cp ${{ github.workspace }}/freemocap/assets/mac_app_files/freemocap.icns ${{ github.workspace }}/freemocap.app/Contents/Resources
           cp ${{ github.workspace }}/freemocap/assets/mac_app_files/Info.plist ${{ github.workspace }}/freemocap.app/Contents
           tar -czvf freemocap.tar.gz freemocap.app
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: freemocap_mac_app
           path: freemocap.tar.gz

--- a/.github/workflows/mac_installer.yml
+++ b/.github/workflows/mac_installer.yml
@@ -64,5 +64,5 @@ jobs:
           tar -czvf freemocap.tar.gz freemocap.app
       - uses: actions/upload-artifact@v3
         with:
-          name: freemocap
+          name: freemocap_mac_app
           path: freemocap.tar.gz

--- a/.github/workflows/mac_installer.yml
+++ b/.github/workflows/mac_installer.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: System Info
         run: |
           uname -a || true

--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
       - name: Download PyApp
         run: |
-          curl -L -o pyapp.zip "https://github.com/ofek/pyapp/releases/download/v0.12.0/source.zip"
+          curl -L -o pyapp.zip "https://github.com/ofek/pyapp/releases/download/v0.22.0/source.zip"
       - name: Unzip PyApp
         run: |
           unzip pyapp.zip
@@ -47,12 +47,14 @@ jobs:
       - name: Create Windows Installer
         run: |
           WORKSPACE=$(cygpath -u "${{ github.workspace}}")
-          cd $WORKSPACE/pyapp-v0.12.0
+          cd $WORKSPACE/pyapp-v0.22.0
           export PYAPP_PROJECT_NAME=freemocap
           export PYAPP_PROJECT_VERSION=v1.2.2
+          export PYAPP_PYTHON_VERSION=3.11
           export PYAPP_PROJECT_DEPENDENCY_FILE=$WORKSPACE/requirements.txt
           export PYAPP_EXEC_SCRIPT=$WORKSPACE/freemocap/__main__.py
           export PYAPP_PIP_EXTRA_ARGS=--no-deps
+          export PYAPP_EXPOSE_ALL_COMMANDS=true
           cargo build --release
           cargo install pyapp --force --root $WORKSPACE
           cd $WORKSPACE

--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set Executable Icon
         run: |
           rcedit "freemocap_app.exe" --set-icon "${{ github.workspace }}/freemocap/assets/logo/freemocap_skelly_logo.ico"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: freemocap_windows_exe
           path: freemocap_app.exe

--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: System Info
         run: |
           systeminfo || true

--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -68,5 +68,5 @@ jobs:
           rcedit "freemocap_app.exe" --set-icon "${{ github.workspace }}/freemocap/assets/logo/freemocap_skelly_logo.ico"
       - uses: actions/upload-artifact@v3
         with:
-          name: freemocap
+          name: freemocap_windows_exe
           path: freemocap_app.exe


### PR DESCRIPTION
One Windows user on Discord is reporting an error of PyApp failing due to what appears to be it installing a Python 3.12 distribution, which we don't support. PyApp has gone through 10 minor versions since we last updated, including changes to prevent this error, so this is a good chance to try upgrading. Upgrading will also get us some improved features.

This PR:
1. Updates PyApp from 0.12 to 0.22
2. Makes the Python version for PyApp to download explicit (3.11 for now)
3. Sets `PYAPP_EXPOSE_ALL_COMMANDS=true`, which will allow users to access the `remove`, `restore`, and `update` commands. Remove deletes the entire PyApp installation, restore fixes improper downloads, and update updates to the latest pip distribution. This fixes a lot of issues we've been having with PyApp. 

Once this merges I will update the release notes with instructions on the PyApp commands