### PR TITLE
Update post_process_skeleton.py

### DIFF
--- a/freemocap/core_processes/post_process_skeleton_data/post_process_skeleton.py
+++ b/freemocap/core_processes/post_process_skeleton_data/post_process_skeleton.py
@@ -83,6 +83,7 @@ def run_post_processing_worker(
         task_list=task_list,
         settings=settings_dictionary,
         all_tasks_finished_callback=lambda results: handle_thread_finished(results, post_processed_data_handler),
+        landmark_names= landmark_names,
     )
     worker_thread.start()
     worker_thread.join()


### PR DESCRIPTION
Fix to make this branch of freemocap work with the `get_model_info_from_skellytracker` branch of `skellyforge` 