### PR TITLE
Patch: Update Skellyviewer when processing finishes

### DIFF
--- a/.github/workflows/coverage-testing.yml
+++ b/.github/workflows/coverage-testing.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Free up disk space
         uses: jlumbroso/free-disk-space@main
         with:
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python 3.x
         uses: wntrblm/nox@2022.8.7
         with:
-          python-versions: "3.9, 3.10, 3.11"
+          python-versions: "3.12"
       - name: Install libegl1
         run: |
           sudo apt-get update

--- a/.github/workflows/linting-flake8.yml
+++ b/.github/workflows/linting-flake8.yml
@@ -10,11 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.x
         uses: wntrblm/nox@2022.8.7
         with:
-          python-versions: "3.11"
+          python-versions: "3.12"
       - name: Run noxfile
         run: |
           nox --session lint

--- a/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
+++ b/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
@@ -179,7 +179,7 @@ def _get_data_to_reproject(
     )
     unique_frame_marker_list = _get_unique_frame_marker_list(indices_above_threshold=indices_above_threshold)
     logger.info(
-        f"number of frame/marker combos with reprojection error above threshold: {len(unique_frame_marker_list)} ({len(unique_frame_marker_list)/total_frame_marker_combos * 100:.1f} percent of total)"
+        f"number of frame/marker combos with reprojection error above threshold: {len(unique_frame_marker_list)} ({len(unique_frame_marker_list) / total_frame_marker_combos * 100:.1f} percent of total)"
     )
 
     cameras_to_remove, frames_to_reproject, markers_to_reproject = _get_camera_frame_marker_lists_to_reproject(

--- a/freemocap/gui/qt/main_window/freemocap_main_window.py
+++ b/freemocap/gui/qt/main_window/freemocap_main_window.py
@@ -185,6 +185,7 @@ class MainWindow(QMainWindow):
             )
 
     def _handle_processing_finished_signal(self):
+        self._update_skelly_viewer_widget()
         if self._controller_group_box.auto_open_in_blender_checked and not self._kill_thread_event.is_set():
             logger.info("'Auto Open in Blender' checkbox is checked - triggering 'Create Blender Scene'")
             self._export_active_recording_to_blender()


### PR DESCRIPTION
We haven't been updating skellyviewer when processing finishes. This PR adds the update call to the `_handle_processing_finished_signal` function in `MainWindow` so that skellyviewer will be updated after processing.