### PR TITLE
Remove residual confidence threshold cutoff

### DIFF
--- a/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
+++ b/freemocap/core_processes/capture_volume_calibration/by_camera_reprojection_filtering.py
@@ -63,10 +63,10 @@ def run_reprojection_error_filtering(
     plot_reprojection_error(
         raw_reprojection_error_frame_marker=skeleton_reprojection_error_fr_mar,
         filtered_reprojection_error_frame_marker=reprojection_filtered_skeleton_reprojection_error_fr_mar,
-        reprojection_error_threshold=np.nanpercentile(
+        reprojection_error_threshold=float(np.nanpercentile(
             skeleton_reprojection_error_cam_fr_mar,
             processing_parameters.anipose_triangulate_3d_parameters_model.reprojection_error_confidence_cutoff,
-        ),
+        )),
         output_folder_path=processing_parameters.recording_info_model.raw_data_folder_path,
     )
     return reprojection_filtered_skel3d_frame_marker_xyz
@@ -82,7 +82,7 @@ def filter_by_reprojection_error(
     output_data_folder_path: Union[str, Path],
     use_triangulate_ransac: bool = False,
     minimum_cameras_to_reproject: int = 3,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     total_cameras = mediapipe_2d_data.shape[0]
     num_cameras_to_remove = 1
 

--- a/freemocap/core_processes/capture_volume_calibration/triangulate_3d_data.py
+++ b/freemocap/core_processes/capture_volume_calibration/triangulate_3d_data.py
@@ -92,12 +92,6 @@ if __name__ == "__main__":
         required=False,
     )
     parser.add_argument(
-        "--mediapipe_confidence_cutoff_threshold",
-        type=float,
-        help="confidence cutoff threshold",
-        required=False,
-    )
-    parser.add_argument(
         "--save_data_as_csv",
         type=bool,
         help="save data as csv",
@@ -112,9 +106,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     mediapipe_2d_data = np.load(args.mediapipe_2d_data_path)
-
-    if args.mediapipe_confidence_cutoff_threshold is None:
-        args.mediapipe_confidence_cutoff_threshold = 0.7  # default
 
     if args.output_data_folder_path is None:
         args.output_data_folder_path = Path(args.mediapipe_2d_data_path).parent
@@ -139,7 +130,6 @@ if __name__ == "__main__":
     ) = triangulate_3d_data(
         anipose_calibration_object=anipose_calibration_object,
         mediapipe_2d_data=mediapipe_2d_data,
-        mediapipe_confidence_cutoff_threshold=args.mediapipe_confidence_cutoff_threshold,
         use_triangulate_ransac=args.use_triangulate_ransac,
     )
     save_mediapipe_3d_data_to_npy(

--- a/freemocap/data_layer/recording_models/post_processing_parameter_models.py
+++ b/freemocap/data_layer/recording_models/post_processing_parameter_models.py
@@ -16,7 +16,6 @@ class AniposeTriangulate3DParametersModel(BaseModel):
     run_reprojection_error_filtering: bool = False
     reprojection_error_confidence_cutoff: float = 90
     minimum_cameras_to_reproject: int = 3
-    confidence_threshold_cutoff: float = 0.5
     use_triangulate_ransac_method: bool = False
     run_3d_triangulation: bool = True
 

--- a/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
+++ b/freemocap/gui/qt/widgets/control_panel/process_mocap_data_panel/parameter_groups/create_parameter_groups.py
@@ -157,14 +157,6 @@ def create_3d_triangulation_parameter_group(
         type="group",
         children=[
             dict(
-                name=ANIPOSE_CONFIDENCE_CUTOFF,
-                type="float",
-                value=parameter_model.confidence_threshold_cutoff,
-                tip="Confidence threshold cut-off for triangulation. "
-                "NOTE - Never trust a machine learning model's estimates of their own confidence! "
-                "TODO - Something similar that uses `reprojection_error` instead of `confidence`",
-            ),
-            dict(
                 name=USE_RANSAC_METHOD,
                 type="bool",
                 value=parameter_model.use_triangulate_ransac_method,
@@ -259,7 +251,6 @@ def extract_parameter_model_from_parameter_tree(
             run_reprojection_error_filtering=parameter_values_dictionary[RUN_REPROJECTION_ERROR_FILTERING],
             reprojection_error_confidence_cutoff=parameter_values_dictionary[REPROJECTION_ERROR_FILTER_THRESHOLD],
             minimum_cameras_to_reproject=parameter_values_dictionary[MINIMUM_CAMERAS_TO_REPROJECT],
-            confidence_threshold_cutoff=parameter_values_dictionary[ANIPOSE_CONFIDENCE_CUTOFF],
             use_triangulate_ransac_method=parameter_values_dictionary[USE_RANSAC_METHOD],
             run_3d_triangulation=parameter_values_dictionary[RUN_3D_TRIANGULATION_NAME],
         ),


### PR DESCRIPTION
Removes references to the `confidence_threshold_cutoff` in the GUI parameters and in the code. 

This parameter was part of the original reprojection filtering, which was removed in #373 and replaced with by camera reprojection filtering in #469.

It has no references in the code outside of the parameter model.