### PR TITLE
Patch pipeline check for single video recordings

### DIFF
--- a/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/pipeline_check.py
+++ b/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/pipeline_check.py
@@ -17,7 +17,7 @@ def processing_pipeline_check(processing_parameters: ProcessingParameterModel) -
             )
 
     if not processing_parameters.anipose_triangulate_3d_parameters_model.run_3d_triangulation:
-        if not status_check_dict["data3d_status_check"]:
+        if not status_check_dict["data3d_status_check"] and not status_check_dict["single_video_check"]:
             raise FileNotFoundError(
                 f"No mediapipe 3d data found at: {processing_parameters.recording_info_model.mediapipe_3d_data_npy_file_path}"
             )


### PR DESCRIPTION
Adds single video check as part of checking for run_3d_triangulation to allow users to process single video recordings regardless of whether the `Run 3d Triangulation?` box is checked, as 3d triangulation is skipped for single video recordings either way

Fixes #622 