### PR TITLE
PATCH: fix path specifier in 1.4 update script

### DIFF
--- a/freemocap/utilities/update_1_4_path_names.py
+++ b/freemocap/utilities/update_1_4_path_names.py
@@ -42,7 +42,7 @@ def update_recording_folder(recording_folder: Path) -> None:
         if (recording_folder / OUTPUT_DATA_FOLDER_NAME / RAW_DATA_FOLDER_NAME).exists():
             rename_raw_data_paths(recording_folder / OUTPUT_DATA_FOLDER_NAME / RAW_DATA_FOLDER_NAME)
         if (recording_folder / OUTPUT_DATA_FOLDER_NAME / CENTER_OF_MASS_FOLDER_NAME).exists():
-            rename_COM_paths(recording_folder / CENTER_OF_MASS_FOLDER_NAME)
+            rename_COM_paths(recording_folder / OUTPUT_DATA_FOLDER_NAME / CENTER_OF_MASS_FOLDER_NAME)
 
 
 def rename_raw_data_paths(raw_data_folder_path: Path) -> None:
@@ -71,6 +71,7 @@ def rename_skeleton_file_path(output_data_folder_path: Path) -> None:
 
 def rename_COM_paths(COM_data_folder_path: Path) -> None:
     print(f"renaming center of mass files in {COM_data_folder_path}")
+
     for file in COM_data_folder_path.iterdir():
         if file.name == "segmentCOM_frame_joint_xyz.npy":
             file.rename(file.parent / "mediapipe_segmentCOM_frame_joint_xyz.npy")


### PR DESCRIPTION
This fixes a bug in the 1.4 update script that looked for the `center_of_mass` folder in the main recording folder instead of in the `output_data` folder. Because the existence check looked in the correct location, this will throw a `FileNotFoundError`