### PR TITLE
Patch: include skellycam config patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ keywords = [
 ]
 
 dependencies = [
-    "skellycam==2024.07.1092",
+    "skellycam==2024.09.1093",
     "skelly_viewer==2024.07.1023",
     "skellyforge==2024.8.1008",
     "skelly_synchronize==2024.07.1032",


### PR DESCRIPTION
We had pushed a patch release to skellycam before merging the PR that included patch. So this PR puts the patch into Freemocap.

I tested and we are able to correctly rotate the cameras now in an environment setup with `pip install -e.` from this branch.