### PR TITLE
More explicit pipeline check error messages

### DIFF
--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_folder.py
@@ -61,7 +61,9 @@ def process_recording_folder(
     try:
         processing_pipeline_check(processing_parameters=recording_processing_parameter_model)
     except FileNotFoundError as e:
-        logger.error("processing parameters are not valid for recording status")
+        logger.error(
+            "processing parameters are not valid for recording status"
+            f" ::: {e}")
         if logging_queue:
             logging_queue.put(e)
         raise e

--- a/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/pipeline_check.py
+++ b/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/pipeline_check.py
@@ -10,24 +10,30 @@ def processing_pipeline_check(processing_parameters: ProcessingParameterModel) -
     status_check_dict = processing_parameters.recording_info_model.status_check
     if not status_check_dict["synchronized_videos_status_check"]:
         raise FileNotFoundError(
-            f"Could not find synchronized_videos folder at {processing_parameters.recording_info_model.synchronized_videos_folder_path}"
+            f"Could not find synchronized_videos folder at {processing_parameters.recording_info_model.synchronized_videos_folder_path}\n"
+            "Synchronized videos are required to run the processing pipeline"
         )
 
     if not processing_parameters.tracking_parameters_model.run_image_tracking:
         if not status_check_dict["data2d_status_check"]:
             raise FileNotFoundError(
-                f"No 2d data found at: {processing_parameters.recording_info_model.data_2d_npy_file_path}"
+                f"No 2d data found at: {processing_parameters.recording_info_model.data_2d_npy_file_path}\n"
+                "2d data is required if you have turned off `Run 2dimage tracking?` in the processing parameters"
             )
 
     if not processing_parameters.anipose_triangulate_3d_parameters_model.run_3d_triangulation:
         if not status_check_dict["data3d_status_check"] and not status_check_dict["single_video_check"]:
             raise FileNotFoundError(
-                f"No 3d data found at: {processing_parameters.recording_info_model.data_3d_npy_file_path}"
+                f"No 3d data found at: {processing_parameters.recording_info_model.data_3d_npy_file_path}\n"
+                "3d data is required if you have selected `Run 3d triangulation?` in the processing parameters"
+                " and have more than 1 video in your synchronized videos folder"
             )
     else:
         if not status_check_dict["calibration_toml_check"] and not status_check_dict["single_video_check"]:
             raise FileNotFoundError(
-                f"No calibration file found at: {processing_parameters.recording_info_model.calibration_toml_path}"
+                f"No calibration file found at: {processing_parameters.recording_info_model.calibration_toml_path}\n"
+                "A calibration.toml file is required if you have selected `Run 3d triangulation?` in the processing parameters"
+                " and have more than 1 video in your synchronized videos folder"
             )
 
 

--- a/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/pipeline_check.py
+++ b/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/pipeline_check.py
@@ -11,28 +11,28 @@ def processing_pipeline_check(processing_parameters: ProcessingParameterModel) -
     if not status_check_dict["synchronized_videos_status_check"]:
         raise FileNotFoundError(
             f"Could not find synchronized_videos folder at {processing_parameters.recording_info_model.synchronized_videos_folder_path}\n"
-            "Synchronized videos are required to run the processing pipeline"
+            "::: Synchronized videos are required to run the processing pipeline"
         )
 
     if not processing_parameters.tracking_parameters_model.run_image_tracking:
         if not status_check_dict["data2d_status_check"]:
             raise FileNotFoundError(
                 f"No 2d data found at: {processing_parameters.recording_info_model.data_2d_npy_file_path}\n"
-                "2d data is required if you have turned off `Run 2dimage tracking?` in the processing parameters"
+                "::: 2d data is required if you have turned off `Run 2dimage tracking?` in the processing parameters"
             )
 
     if not processing_parameters.anipose_triangulate_3d_parameters_model.run_3d_triangulation:
         if not status_check_dict["data3d_status_check"] and not status_check_dict["single_video_check"]:
             raise FileNotFoundError(
                 f"No 3d data found at: {processing_parameters.recording_info_model.data_3d_npy_file_path}\n"
-                "3d data is required if you have selected `Run 3d triangulation?` in the processing parameters"
+                "::: 3d data is required if you have selected `Run 3d triangulation?` in the processing parameters"
                 " and have more than 1 video in your synchronized videos folder"
             )
     else:
         if not status_check_dict["calibration_toml_check"] and not status_check_dict["single_video_check"]:
             raise FileNotFoundError(
                 f"No calibration file found at: {processing_parameters.recording_info_model.calibration_toml_path}\n"
-                "A calibration.toml file is required if you have selected `Run 3d triangulation?` in the processing parameters"
+                ":::A calibration.toml file is required if you have selected `Run 3d triangulation?` in the processing parameters"
                 " and have more than 1 video in your synchronized videos folder"
             )
 

--- a/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/pipeline_check.py
+++ b/freemocap/core_processes/process_motion_capture_videos/processing_pipeline_functions/pipeline_check.py
@@ -18,7 +18,7 @@ def processing_pipeline_check(processing_parameters: ProcessingParameterModel) -
         if not status_check_dict["data2d_status_check"]:
             raise FileNotFoundError(
                 f"No 2d data found at: {processing_parameters.recording_info_model.data_2d_npy_file_path}\n"
-                "::: 2d data is required if you have turned off `Run 2dimage tracking?` in the processing parameters"
+                "::: 2d data is required if you have turned off `Run 2d image tracking?` in the processing parameters"
             )
 
     if not processing_parameters.anipose_triangulate_3d_parameters_model.run_3d_triangulation:

--- a/freemocap/utilities/update_1_4_path_names.py
+++ b/freemocap/utilities/update_1_4_path_names.py
@@ -42,7 +42,7 @@ def update_recording_folder(recording_folder: Path) -> None:
         if (recording_folder / OUTPUT_DATA_FOLDER_NAME / RAW_DATA_FOLDER_NAME).exists():
             rename_raw_data_paths(recording_folder / OUTPUT_DATA_FOLDER_NAME / RAW_DATA_FOLDER_NAME)
         if (recording_folder / OUTPUT_DATA_FOLDER_NAME / CENTER_OF_MASS_FOLDER_NAME).exists():
-            rename_COM_paths(recording_folder / CENTER_OF_MASS_FOLDER_NAME)
+            rename_COM_paths(recording_folder / OUTPUT_DATA_FOLDER_NAME / CENTER_OF_MASS_FOLDER_NAME)
 
 
 def rename_raw_data_paths(raw_data_folder_path: Path) -> None:
@@ -71,6 +71,7 @@ def rename_skeleton_file_path(output_data_folder_path: Path) -> None:
 
 def rename_COM_paths(COM_data_folder_path: Path) -> None:
     print(f"renaming center of mass files in {COM_data_folder_path}")
+
     for file in COM_data_folder_path.iterdir():
         if file.name == "segmentCOM_frame_joint_xyz.npy":
             file.rename(file.parent / "mediapipe_segmentCOM_frame_joint_xyz.npy")


### PR DESCRIPTION
We get a lot of questions about the `processing parameters are not valid for recording status` error that comes from the pipeline check. This error means the pipeline cannot successfully run, but the more descriptive error is hidden in the terminal output. Even that simply says what file wasn't found, and not why that file is required in the first place.

This PR adds a descriptive message to each error in the pipeline check, to let the user know what combination of values led to the pipeline check failing. It then passes that data to the GUI, so the message is clearly shown to users without having to check the terminal.

The improved output:
<img width="1243" alt="Improved output" src="https://github.com/user-attachments/assets/ffc891c1-ba08-480a-8289-86082cd3e2aa">

The current output:
<img width="1241" alt="Current output" src="https://github.com/user-attachments/assets/49f6a95b-d0f2-4427-9b3f-b7a33838d82a">
