### PR TITLE
Remove redundant code path in image tests

### DIFF
--- a/freemocap/tests/test_image_tracking_data_shape.py
+++ b/freemocap/tests/test_image_tracking_data_shape.py
@@ -16,39 +16,12 @@ def test_image_tracking_data_exists(
     image_tracking_data: Union[str, Path],
 ):
     """
-    test that the `2d detection` process worked correctly by checking:
-
-    There is an `.npy` file containing the 2d data in the `output_data_folder`
-    2. The dimensions of that `npy` (number of cameras, number of frames, [ need to do - number of tracked points], [pixelX, pixelY] matches the videos in the `synchronized videos` folder
-
-    TODO - check number of tracked points vs 'expected' number of tracked points
+    test that the `2d detection` process worked correctly by checking that there is an `.npy` file containing the 2d data in the `output_data_folder`
     """
 
     assert Path(image_tracking_data).is_file(), f"{image_tracking_data} is not a file"
 
-    image_tracking_data = np.load(image_tracking_data)
 
-    list_of_video_paths = get_video_paths(Path(synchronized_video_folder_path))
-    number_of_videos = len(list_of_video_paths)
-    assert (
-        image_tracking_data.shape[0] == number_of_videos
-    ), f"Number of videos in {image_tracking_data} does not match number of videos in synchronized videos folder"
-
-    frame_counts = list(get_number_of_frames_of_videos_in_a_folder(synchronized_video_folder_path).values())
-
-    assert (
-        len(set(frame_counts)) == 1
-    ), f"Videos in {synchronized_video_folder_path} have different frame counts: {frame_counts}"
-    assert (
-        image_tracking_data.shape[1] == frame_counts[0]
-    ), f"Number of frames in {image_tracking_data} does not match number of frames of videos in {synchronized_video_folder_path}"
-
-    # TODO - check number of tracked points vs 'expected' number of tracked points
-
-    assert (
-        image_tracking_data.shape[3] == 3
-    ), f"Data has {image_tracking_data.shape[3]} dimensions, expected 3 dimensions"
-    
 @pytest.mark.usefixtures("synchronized_video_folder_path", "image_tracking_data")
 def test_image_tracking_data_shape(
     synchronized_video_folder_path: Union[str, Path],


### PR DESCRIPTION
We had previously split `test_image_tracking_data_exists` and `test_image_tracking_data_shape` into two different functions, but did not remove the "testing data shape" part of the "testing data exists" function. This led to redundant code being run twice - since this is run in the gui loop as part of the active info recording tab, the extra work is being done quite often. It also adds another code path that would require changing to change functionality.

This PR removes the redundant code path, to the existence check *only* checks existence.