### PR TITLE
turn off parallel in triangulate simple jit

### DIFF
--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/freemocap_anipose.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/freemocap_anipose.py
@@ -29,7 +29,7 @@ numba_logger.setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 
-@jit(nopython=True, parallel=True)
+@jit(nopython=True, parallel=False)
 def triangulate_simple(points, camera_mats):
     num_cams = len(camera_mats)
     A = np.zeros((num_cams * 2, 4))


### PR DESCRIPTION
This PR turns off the `parallel` flag in the Numba `@jit` decorator for the `triangulate_simple` function in `freemocap_anipose`.

## Benchmarking and Profiling
Using the simple benchmark script in [philip/benchmark_anipose](https://github.com/freemocap/freemocap/blob/philip/benchmark_anipose/experimental/benchmark/benchmark_anipose.py), I got the following times for triangulating the test data. Each sessions loads the data once and then triangulates 5 times to get a mean. The attached files are [speedscope](https://www.speedscope.app/) compatible files, and you can load them into the website to get a flamegraph of the session.

Here's the baseline, where the only change is not logging progress:
```
This round triangulation time is: 58.820315458 seconds for 222 frames
This round average time per frame is: 0.26495637593693694 seconds
This round triangulation time is: 51.093070208 seconds for 222 frames
This round average time per frame is: 0.2301489649009009 seconds
This round triangulation time is: 51.928427667 seconds for 222 frames
This round average time per frame is: 0.23391183633783785 seconds
This round triangulation time is: 47.698998916 seconds for 222 frames
This round average time per frame is: 0.21486035547747748 seconds
This round triangulation time is: 49.74191775 seconds for 222 frames
This round average time per frame is: 0.22406269256756756 seconds
Total mean triangulation time is: 51.856545999800005 seconds for 222 frames over 5 runs
Average time per frame is: 0.046717609008828834 seconds
```
[triangulate_jit_no_progress_5_rounds.json](https://github.com/user-attachments/files/17263670/triangulate_jit_no_progress_5_rounds.json)

Next, with the jit entirely turned off:
```
This round triangulation time is: 3.702174583 seconds for 222 frames
This round average time per frame is: 0.016676462085585587 seconds
This round triangulation time is: 3.284485209 seconds for 222 frames
This round average time per frame is: 0.014794978418918919 seconds
This round triangulation time is: 3.144898541 seconds for 222 frames
This round average time per frame is: 0.014166209644144143 seconds
This round triangulation time is: 3.274605708 seconds for 222 frames
This round average time per frame is: 0.014750476162162162 seconds
This round triangulation time is: 3.52456975 seconds for 222 frames
This round average time per frame is: 0.015876440315315314 seconds
Total mean triangulation time is: 3.3861467582 seconds for 222 frames over 5 runs
Average time per frame is: 0.003050582665045045 seconds
```
[triangulate_no_jit_5_rounds.json](https://github.com/user-attachments/files/17263672/triangulate_no_jit_5_rounds.json)

And finally, the change I'm proposing, which is just turning off the `parallel` flag in the jit. So Numba still runs, but without attempting to parallel the function.
```
This round triangulation time is: 2.500579042 seconds for 222 frames
This round average time per frame is: 0.011263869558558558 seconds
This round triangulation time is: 1.364891166 seconds for 222 frames
This round average time per frame is: 0.006148158405405405 seconds
This round triangulation time is: 1.33356625 seconds for 222 frames
This round average time per frame is: 0.0060070551801801805 seconds
This round triangulation time is: 1.347647875 seconds for 222 frames
This round average time per frame is: 0.006070485923423423 seconds
This round triangulation time is: 1.370834958 seconds for 222 frames
This round average time per frame is: 0.006174932243243243 seconds
Total mean triangulation time is: 1.5835038581999998 seconds for 222 frames over 5 runs
Average time per frame is: 0.0014265800524324323 seconds
```
[triangulate_no_parallel_5_rounds.json](https://github.com/user-attachments/files/17263673/triangulate_no_parallel_5_rounds.json)

## Analysis
Turning off the jit is 15.3 times faster than using the jit as is. Using the jit with parallel off is 32.7 times faster than using the jit as is, and over twice as fast not using the jit at all. If you look at the flame graph for the jit-as-is (first case above), the jit just isn't able to speed up the `triangulate` function significantly, as each iteration clearly takes significant time.

On my machine (M1 mac) when using the GUI, this makes triangulation run through 122,766 points in ~2 seconds, averaging roughly 61383 it/s. With parallel turned on, the same 122,766 points take 268 seconds, averaging roughly 458 it/s. This is a 134 times speed improvement in triangulating!

My suspicion is that some OpenMP errors that have been appearing on macOS for a while are related to a heavy slow down with the parallel JIT. So I don't expect as significant of improvements on other machines, but even without performance gains it's worth turning off the parallel on darwin systems. 

## TODOS:
- [x] check if the other `@jit` decorated functions will have similar improvements
    - [x] `reprojection_error` - hardly any improvement
    - [x] `_error_fun_bundle` - a slight decrease in performance turning `parallel=False` (from 5.91 to 6.23 seconds mean across 5 trials).
    - [x] `_error_fun_triangulation` - this is only used in the `triangulate_optim` function, which we don't use in Freemocap
- [ ] check this behavior on other operating systems

