### PR TITLE
fix docs and privacy policy links

### DIFF
--- a/freemocap/gui/qt/widgets/home_widget.py
+++ b/freemocap/gui/qt/widgets/home_widget.py
@@ -128,11 +128,11 @@ class HomeWidget(QWidget):
         hbox = QHBoxLayout()
         self._layout.addLayout(hbox)
         hbox.addStretch(1)
-        privacy_policy_link_string = '<a href="https://freemocap.github.io/documentation/community/privacy_policy/" style="color: #333333;">privacy policy</a>'
+        privacy_policy_link_string = '<a href="https://freemocap.github.io/documentation/privacy-policy.html" style="color: #333333;">privacy policy</a>'
         privacy_policy_link_label = QLabel(privacy_policy_link_string)
         privacy_policy_link_label.setOpenExternalLinks(True)
         hbox.addWidget(privacy_policy_link_label)
-        docs_string = '<a href="https://freemocap.github.io/documentation/" style="color: #333333;">docs</a>'
+        docs_string = '<a href="https://freemocap.github.io/documentation/index_md.html" style="color: #333333;">docs</a>'
         docs_string = QLabel(docs_string)
         docs_string.setOpenExternalLinks(True)
         hbox.addWidget(docs_string, alignment=Qt.AlignmentFlag.AlignCenter)


### PR DESCRIPTION
Fixes #655 by updating the privacy policy and docs links.

The docs link was working but after a redirect for me, but this should hit the final url directly.