### PR TITLE
bump freemocap_blender_addon version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "skellyforge==2024.12.1009",
     "skelly_synchronize==2024.07.1032",
     "skellytracker[all]==2024.09.1019",
-    "ajc27_freemocap_blender_addon==v2024.12.1033",
+    "ajc27_freemocap_blender_addon==v2024.12.1034",
     "opencv-contrib-python==4.8.*",
     "toml==0.10.2",
     "aniposelib==0.4.3",


### PR DESCRIPTION
Bump to include fix to `images_as_planes` api in blender 4.2+ (https://github.com/freemocap/freemocap_blender_addon/pull/31) 