### PR TITLE
Update pyproject.toml

### DIFF
--- a/.github/workflows/version-testing-1.yml
+++ b/.github/workflows/version-testing-1.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install libegl1
         run: |
           sudo apt-get update
-          sudo apt-get install libegl1-mesa
+          sudo apt-get install libgl1
       - name: Run noxfile
         run: |
           nox --session test_10

--- a/.github/workflows/version-testing-2.yml
+++ b/.github/workflows/version-testing-2.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install libegl1
         run: |
           sudo apt-get update
-          sudo apt-get install libegl1-mesa
+          sudo apt-get install libgl1 
       - name: Run noxfile
         run: |
           nox --session test_11_12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "skellyforge==2024.12.1009",
     "skelly_synchronize==2024.07.1032",
     "skellytracker[all]==2024.09.1019",
-    "ajc27_freemocap_blender_addon==v2024.12.1034",
+    "ajc27_freemocap_blender_addon==v2025.1.1035",
     "opencv-contrib-python==4.8.*",
     "toml==0.10.2",
     "aniposelib==0.4.3",


### PR DESCRIPTION
The blender addon failed to properly push to pypi for `v2024.12.1034`, so the `pyproject.toml` in `freemocap` was pointing to a non-existent blender version, causing failure from trying `pip install -e.`. This should fix that. 

EDIT:

Also updating the `libgl1` version in the nox version testing - the old version we were using was deprecated, leading to failure on the nox tests