### PR TITLE
Fix documentation links

### DIFF
--- a/.github/workflows/coverage-testing.yml
+++ b/.github/workflows/coverage-testing.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install libegl1
         run: |
           sudo apt-get update
-          sudo apt-get install libegl1-mesa
+          sudo apt-get install libgl1
       - name: Run noxfile
         run: |
           nox --session coverage

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install libegl1
         run: |
           sudo apt-get update
-          sudo apt-get install -y libegl1-mesa
+          sudo apt-get install -y libgl1
       - name: Run Tests with Pytest
         run: |
           pip install pytest

--- a/freemocap/gui/qt/actions_and_menus/actions.py
+++ b/freemocap/gui/qt/actions_and_menus/actions.py
@@ -2,6 +2,7 @@ from PySide6.QtCore import QUrl
 from PySide6.QtGui import QAction, QDesktopServices
 
 from freemocap.system.paths_and_filenames.file_and_folder_names import (
+    DOCUMENTATION_WELCOME_URL,
     FIGSHARE_SAMPLE_ZIP_FILE_URL,
     FIGSHARE_TEST_ZIP_FILE_URL,
 )
@@ -83,7 +84,7 @@ class Actions:
         # Help
         self.open_docs_action = QAction(OPEN_DOCS_ACTION_NAME, parent=freemocap_main_window)
         self.open_docs_action.triggered.connect(
-            lambda: QDesktopServices.openUrl(QUrl("https://freemocap.github.io/documentation/index_md.html"))
+            lambda: QDesktopServices.openUrl(QUrl(DOCUMENTATION_WELCOME_URL))
         )
 
         self.freemocap_foundation_action = QAction(FREEMOCAP_FOUNDATION_ACTION_NAME, parent=freemocap_main_window)

--- a/freemocap/gui/qt/widgets/home_widget.py
+++ b/freemocap/gui/qt/widgets/home_widget.py
@@ -22,7 +22,7 @@ from freemocap.gui.qt.actions_and_menus.actions import (
 )
 from freemocap.gui.qt.utilities.save_and_load_gui_state import GuiState, save_gui_state
 from freemocap.gui.qt.widgets.logo_svg_widget import LogoSvgWidget
-from freemocap.system.paths_and_filenames.file_and_folder_names import PATH_TO_FREEMOCAP_LOGO_SVG
+from freemocap.system.paths_and_filenames.file_and_folder_names import DOCUMENTATION_HOME, DOCUMENTATION_PRIVACY_POLICY_URL, PATH_TO_FREEMOCAP_LOGO_SVG
 from freemocap.system.paths_and_filenames.path_getters import get_gui_state_json_path
 
 logger = logging.getLogger(__name__)
@@ -128,11 +128,11 @@ class HomeWidget(QWidget):
         hbox = QHBoxLayout()
         self._layout.addLayout(hbox)
         hbox.addStretch(1)
-        privacy_policy_link_string = '<a href="https://freemocap.github.io/documentation/privacy-policy.html" style="color: #333333;">privacy policy</a>'
+        privacy_policy_link_string = f'<a href="{DOCUMENTATION_PRIVACY_POLICY_URL}" style="color: #333333;">privacy policy</a>'
         privacy_policy_link_label = QLabel(privacy_policy_link_string)
         privacy_policy_link_label.setOpenExternalLinks(True)
         hbox.addWidget(privacy_policy_link_label)
-        docs_string = '<a href="https://freemocap.github.io/documentation/index_md.html" style="color: #333333;">docs</a>'
+        docs_string = f'<a href="{DOCUMENTATION_HOME}" style="color: #333333;">docs</a>'
         docs_string = QLabel(docs_string)
         docs_string.setOpenExternalLinks(True)
         hbox.addWidget(docs_string, alignment=Qt.AlignmentFlag.AlignCenter)

--- a/freemocap/gui/qt/widgets/welcome_screen_dialog.py
+++ b/freemocap/gui/qt/widgets/welcome_screen_dialog.py
@@ -4,7 +4,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QVBoxLayout, QDialog, QCheckBox, QPushButton, QLabel, QHBoxLayout, QFrame
 
 from freemocap.gui.qt.utilities.save_and_load_gui_state import GuiState, save_gui_state
-from freemocap.system.paths_and_filenames.file_and_folder_names import SPARKLES_EMOJI_STRING
+from freemocap.system.paths_and_filenames.file_and_folder_names import DOCUMENTATION_MULTI_CAMERA_URL, DOCUMENTATION_SINGLE_CAMERA_URL, SPARKLES_EMOJI_STRING
 from freemocap.system.paths_and_filenames.path_getters import get_gui_state_json_path
 
 
@@ -38,7 +38,7 @@ class WelcomeScreenDialog(QDialog):
         single_camera_docs_label.setWordWrap(True)
         self._layout.addWidget(single_camera_docs_label, 1)
 
-        single_camera_recording_doc_link_string = '&#10132; <a href="https://freemocap.github.io/documentation/single-camera-recording.html" style="color: #333333;"> Single camera recording tutorial</a>'
+        single_camera_recording_doc_link_string = f'&#10132; <a href="{DOCUMENTATION_SINGLE_CAMERA_URL}" style="color: #333333;"> Single camera recording tutorial</a>'
         single_camera_doc_link = QLabel(single_camera_recording_doc_link_string)
         single_camera_doc_link.setOpenExternalLinks(True)
         self._layout.addWidget(single_camera_doc_link)
@@ -48,7 +48,7 @@ class WelcomeScreenDialog(QDialog):
         multi_camera_docs_label.setWordWrap(True)
         self._layout.addWidget(multi_camera_docs_label, 1)
 
-        multi_camera_recording_doc_link_string = '&#10132; <a href="https://freemocap.github.io/documentation/multi-camera-calibration.html" style="color: #333333;"> Multi camera recording tutorial</a>'
+        multi_camera_recording_doc_link_string = f'&#10132; <a href="{DOCUMENTATION_MULTI_CAMERA_URL}" style="color: #333333;"> Multi camera recording tutorial</a>'
         multi_camera_doc_link = QLabel(multi_camera_recording_doc_link_string)
         multi_camera_doc_link.setOpenExternalLinks(True)
         self._layout.addWidget(multi_camera_doc_link)

--- a/freemocap/system/paths_and_filenames/file_and_folder_names.py
+++ b/freemocap/system/paths_and_filenames/file_and_folder_names.py
@@ -53,6 +53,13 @@ FIGSHARE_TEST_ZIP_FILE_URL = "https://figshare.com/ndownloader/files/45797073"
 FREEMOCAP_TEST_DATA_RECORDING_NAME = "freemocap_test_data"
 FREEMOCAP_SAMPLE_DATA_RECORDING_NAME = "freemocap_sample_data"
 
+# documentation links
+DOCUMENTATION_HOME = "https://freemocap.github.io/documentation/"
+DOCUMENTATION_WELCOME_URL = "https://freemocap.github.io/documentation/getting_started/"
+DOCUMENTATION_SINGLE_CAMERA_URL = "https://freemocap.github.io/documentation/getting_started/single_camera_recording/"
+DOCUMENTATION_MULTI_CAMERA_URL = "https://freemocap.github.io/documentation/getting_started/multi_camera_calibration/"
+DOCUMENTATION_PRIVACY_POLICY_URL = "https://freemocap.github.io/documentation/community/privacy_policy/"
+
 # logo
 PATH_TO_FREEMOCAP_LOGO_SVG = str(Path(freemocap.__file__).parent / "assets/logo/freemocap-logo-black-border.svg")
 


### PR DESCRIPTION
Fixes #670 

  A few of our links were never updated with the conversion to Writerside. This PR updates those links, and moves them from hardcoded links spread throughout the code to `file_and_folder_names.py`, so they are easier to update in the future