### PR TITLE
Patch: Fix Butterworth output not making it to final data

### DIFF
--- a/freemocap/core_processes/post_process_skeleton_data/post_process_skeleton.py
+++ b/freemocap/core_processes/post_process_skeleton_data/post_process_skeleton.py
@@ -74,7 +74,7 @@ def run_post_processing_worker(
 ) -> np.ndarray:
     def handle_thread_finished(results, post_processed_data_handler: PostProcessedDataHandler):
         # TODO: skellyforge should handle getting the final task results regardless of what was run
-        if hasattr(results, TASK_FILTERING) and results[TASK_FILTERING] is not None:
+        if TASK_FILTERING in results and results[TASK_FILTERING] is not None:
             processed_skeleton = results[TASK_FILTERING]["result"]
         else:
             processed_skeleton = results[TASK_INTERPOLATION]["result"]


### PR DESCRIPTION
A `hasattr` check on a dictionary was preventing freemocap from using the filtered data returned from skellyforge. Dictionaries don't have the keys as attributes, so it was consistently failing.

As a patch I've replaced the `hasattr` check with the best practice `in` check.

Note the `TODO` I added when this was merged though, that skellyforge should be deciding what its return data is, not freemocap.