### PR TITLE
Aaron/fix pin to 0 code

### DIFF
--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
@@ -128,9 +128,10 @@ class AniposeCameraCalibrator:
             cam_group (freemocap_anipose.CameraGroup): A group of calibrated cameras whose extrinsics will be adjusted in place.
         """
 
-        self.align_rotations_to_cam0(cam_group=cam_group)
-        cam_group = self.shift_origin_to_cam0(cam_group=cam_group)
-
+        rvecs_new = self.align_rotations_to_cam0(cam_group=cam_group)
+        cam_group.set_rotations(rvecs_new)
+        tvecs_new = self.shift_origin_to_cam0(cam_group=cam_group)
+        cam_group.set_translations(tvecs_new)
         return cam_group
 
     def align_rotations_to_cam0(self, cam_group:freemocap_anipose.CameraGroup):
@@ -148,8 +149,7 @@ class AniposeCameraCalibrator:
             Ri_new,_ = cv2.Rodrigues(Ri @ R0.T)
             rvecs_new[i] = Ri_new.flatten()
 
-        cam_group.set_rotations(rvecs_new)
-        return cam_group
+        return rvecs_new
     
     def shift_origin_to_cam0(self, cam_group:freemocap_anipose.CameraGroup):
         # Get original translation and rotation vectors
@@ -176,7 +176,4 @@ class AniposeCameraCalibrator:
             delta_to_origin_camera_i = Ri @ delta_to_origin_world
             # Update the translation vector
             new_tvecs[cam_i, :] = tvecs[cam_i, :] + delta_to_origin_camera_i
-
-        # Update the camera group with the new translations
-        cam_group.set_translations(new_tvecs)
-        return cam_group
+        return new_tvecs

--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Callable, Union
 
 import numpy as np
+import cv2
 
 from freemocap.core_processes.capture_volume_calibration.anipose_camera_calibration import (
     freemocap_anipose,
@@ -115,21 +116,24 @@ class AniposeCameraCalibrator:
         return calibration_folder_toml_path
 
     def pin_camera_zero_to_origin(self, _anipose_camera_group_object):
-        import cv2
 
         original_translation_vectors = _anipose_camera_group_object.get_translations()
         original_rotation_vectors = _anipose_camera_group_object.get_rotations()
         camera_0_translation = original_translation_vectors[0, :]
         camera_0_rotation = original_rotation_vectors[0,:]
 
-        R0, _ = cv2.Rodrigues(camera_0_rotation)  #gets 3x3 rotation matrix for world -> cam 0
-        delta_to_origin_world = - R0.T @ camera_0_translation #the vector that moves camera 0 to the origin in the world reference frame (https://docs.opencv.org/4.x/d9/d0c/group__calib3d.html)
+        #gets 3x3 rotation matrix for world -> cam 0
+        R0, _ = cv2.Rodrigues(camera_0_rotation)  
+        #the vector that moves camera 0 to the origin in the world reference frame (https://docs.opencv.org/4.x/d9/d0c/group__calib3d.html)
+        delta_to_origin_world = - R0.T @ camera_0_translation 
         
 
         altered_translation_vectors = np.zeros(original_translation_vectors.shape)
         for cam_i in range(original_translation_vectors.shape[0]):
-            Ri, _ = cv2.Rodrigues(original_rotation_vectors[cam_i,:]) #gets 3x3 rotation matrix for world -> cam i
-            delta_to_origin_camera_i = Ri @ delta_to_origin_world #changes the delta origin vector from world reference into cam i reference
+            #gets 3x3 rotation matrix for world -> cam i
+            #changes the delta origin vector from world reference into cam i reference
+            Ri, _ = cv2.Rodrigues(original_rotation_vectors[cam_i,:]) 
+            delta_to_origin_camera_i = Ri @ delta_to_origin_world 
             altered_translation_vectors[cam_i, :] = original_translation_vectors[cam_i,:] + delta_to_origin_camera_i 
 
         _anipose_camera_group_object.set_translations(altered_translation_vectors)

--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
@@ -148,7 +148,6 @@ class AniposeCameraCalibrator:
             Ri,_ = cv2.Rodrigues(rvecs[i])
             Ri_new,_ = cv2.Rodrigues(Ri @ R0.T)
             rvecs_new[i] = Ri_new.flatten()
-
         return rvecs_new
     
     def shift_origin_to_cam0(self, cam_group:freemocap_anipose.CameraGroup):


### PR DESCRIPTION
After a good bit of digging, I believe I've found the issue the `pin_camera_0_to_origin` code, which lies in how we're handling different coordinate systems.

Currently we're trying to move each cameras `tvec` by applying a transformation that would place camera 0's position at [0,0,0]. However, each cameras `tvec` exists in its own local reference frame, not in the world coordinate system. 

So currently we calculate a translation in the context of camera 0's coordinate system and then try to apply this same translation to other cameras with different orientations. This means that this function hasn't been rigidly moving the cameras as a set - it's been changing the spatial relationships between cameras.   This explains why different 'translations' that have been applied (for example, how which video was listed as 'camera 0' led to a different `translation to origin` vector) has led to differently scaled data.

The solution that I've tried to implement here is to calculate the translation needed to get camera 0 to the origin in the world coordinate system, not in camera 0's specific coordinate system. Then, we take this world-space translation, transform it into each cameras local coordinate system, and apply it. 