### PR TITLE
detect variations of "Blender.app" on macOS

### DIFF
--- a/freemocap/gui/qt/widgets/control_panel/export_data_control_panel.py
+++ b/freemocap/gui/qt/widgets/control_panel/export_data_control_panel.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from pathlib import Path
 
 from PySide6.QtWidgets import (
@@ -79,7 +80,7 @@ class VisualizationControlPanel(QWidget):
 
         if "blender" in path_selection[0]:
             self._blender_executable_path = path_selection[0]
-        elif "Blender.app" in path_selection[0]:
+        elif re.match(r".*Blender.*\.app$", path_selection[0]):
             self._blender_executable_path = path_selection[0] + "/Contents/MacOS/Blender"  # executable is buried on mac
         else:
             self._blender_executable_path = BLENDER_EXECUTABLE_PATH_MISSING_STRING


### PR DESCRIPTION
On macOS the Blender application bundle can be relocated or renamed; for example maybe the user has multiple versions:

```
/Applications/Blender-4.0.2.app
/Applications/Blender-4.2.8.app
```

This PR uses a regex to accept any bundle containing the string "Blender" and ending with ".app"