### PR TITLE
Update skellytracker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "skelly_viewer==2025.04.1028",
     "skellyforge==2024.12.1009",
     "skelly_synchronize==2025.04.1037",
-    "skellytracker[all]==2025.04.1021",
+    "skellytracker[all]==2025.5.1022",
     "ajc27_freemocap_blender_addon==v2025.1.1035",
     "opencv-contrib-python==4.8.*",
     "toml==0.10.2",


### PR DESCRIPTION
New `skellytracker` version that updates the `YOLO` tracker from `v8` to `v11` and gets the `YOLOMediapipeComboTracker` working again. 