### PR TITLE
use skellytracker for charuco detection in anipose

### DIFF
--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/anipose_camera_calibrator.py
@@ -21,7 +21,6 @@ from freemocap.utilities.get_video_paths import get_video_paths
 
 from freemocap.core_processes.capture_volume_calibration.anipose_camera_calibration.charuco_groundplane_utils import (
     compute_basis_vectors_of_new_reference, 
-    get_charuco_2d_data,
     get_charuco_frame,
 )
 
@@ -192,15 +191,15 @@ class AniposeCameraCalibrator:
     def set_charuco_board_as_groundplane(self, cam_group:freemocap_anipose.CameraGroup):
         # Get the camera group object
         logger.info("Getting 2d Charuco data")
-        charuco_2d_xy = get_charuco_2d_data(
-            calibration_videos_folder_path=self._calibration_videos_folder_path,
-            num_processes=3
-        )
-        logger.info("Charuco 2d data detected successfully with shape: "
+        charuco_2d_xy = cam_group.charuco_2d_data
+        if charuco_2d_xy is None:
+            error_message = "Charuco 2d data was not retrieved successfully. Check for an error during calibration."
+            logger.error(error_message)
+            raise ValueError(error_message)
+        logger.info("Charuco 2d data retrieved successfully with shape: "
                     f"{charuco_2d_xy.shape}")
 
         num_cameras, num_frames, num_tracked_points,_ = charuco_2d_xy.shape
-        charuco_2d_xy = charuco_2d_xy.astype(np.float64)
         charuco_2d_flat = charuco_2d_xy.reshape(num_cameras, -1, 2)
 
         logger.info("Getting 3d Charuco data")

--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/charuco_groundplane_utils.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/charuco_groundplane_utils.py
@@ -30,15 +30,5 @@ def compute_basis_vectors_of_new_reference(charuco_frame: np.ndarray,
     return x_hat, y_hat, z_hat
 
 
-def get_charuco_2d_data(calibration_videos_folder_path: Union[str, Path],
-                        num_processes: int = 1):
-    return process_folder_of_videos(
-        model_info=CharucoModelInfo(),
-        tracking_params=CharucoTrackingParams(),
-        synchronized_video_path=Path(calibration_videos_folder_path),
-        num_processes=num_processes
-    )
-
-
 def get_charuco_frame(charuco_3d_data: np.ndarray):
     return charuco_3d_data[10, :, :]

--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/freemocap_anipose.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/freemocap_anipose.py
@@ -1847,6 +1847,10 @@ class CameraGroup:
         if board.total_size != 24: 
             raise ValueError("AniposeCharucoBoard only supports 24 corners, got {}".format(board.total_size))
         self._get_charuco_2d_data(videos)
+
+        if self.charuco_2d_data is None:
+            raise ValueError("Charuco 2D data has not been initialized. Call _get_charuco_2d_data() first, or check for errors in the video processing.")
+        
         all_rows = []
 
         num_cameras, num_frames, _, _ = self.charuco_2d_data.shape


### PR DESCRIPTION
Replaces charuco detection in Anipose with skellytracker's CharucoTracker. This gives us more control over the calibration pipeline, including getting parallel processing of the calibration videos. It also allows us to use the same detection for both the initial calibration and the charuco groundplane calculation.

II'll run through some tests of it, but the biggest thing I want to check for is error handling when there isn't a detection. As long as we don't regress there it should be good.