### PR TITLE
Update deprecated pydantic dict method

### DIFF
--- a/experimental/batch_process/batch_process.py
+++ b/experimental/batch_process/batch_process.py
@@ -66,7 +66,7 @@ def process_recording_without_gui(
     else:
         logging.warning("No camera calibration toml file provided. May cause an error with multicamera recordings.")
 
-    recording_info_dict = rec.dict(exclude={"recording_info_model"})
+    recording_info_dict = rec.model_dump(exclude={"recording_info_model"})
 
     Path(rec.recording_info_model.output_data_folder_path).mkdir(parents=True, exist_ok=True)
 

--- a/freemocap/core_processes/process_motion_capture_videos/process_recording_headless.py
+++ b/freemocap/core_processes/process_motion_capture_videos/process_recording_headless.py
@@ -60,7 +60,7 @@ def process_recording_headless(
                 f"There are {number_of_videos} videos. Must provide a calibration toml file for multicamera recordings."
             )
 
-    recording_info_dict = rec.dict(exclude={"recording_info_model"})
+    recording_info_dict = rec.model_dump(exclude={"recording_info_model"})
 
     Path(rec.recording_info_model.output_data_folder_path).mkdir(parents=True, exist_ok=True)
 

--- a/freemocap/gui/qt/workers/process_motion_capture_data_thread_worker.py
+++ b/freemocap/gui/qt/workers/process_motion_capture_data_thread_worker.py
@@ -33,11 +33,11 @@ class ProcessMotionCaptureDataThreadWorker(QThread):
 
     def run(self):
         logger.info(
-            f"Beginning processing of motion capture data with parameters: {self._processing_parameters.dict(exclude={'tracking_model_info'})}"
+            f"Beginning processing of motion capture data with parameters: {self._processing_parameters.model_dump(exclude={'tracking_model_info'})}"
         )
         self._kill_event.clear()
 
-        recording_info_dict = self._processing_parameters.dict(exclude={"recording_info_model"})
+        recording_info_dict = self._processing_parameters.model_dump(exclude={"recording_info_model"})
         Path(self._processing_parameters.recording_info_model.output_data_folder_path).mkdir(
             parents=True, exist_ok=True
         )


### PR DESCRIPTION
## PR Summary
This small PR continues the work started in [PR #711](https://github.com/freemocap/freemocap/pull/711) by updating the deprecated `dict()` method in Pydantic models to the recommended `model_dump()` method. This change eliminates the following deprecation warning found in the [CI logs](https://github.com/freemocap/freemocap/actions/runs/16302123534/job/46039113739#step:6:3504):

```python
PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
```