### PR TITLE
Cleanup groundplane UI

### DIFF
--- a/freemocap/gui/qt/freemocap_main.py
+++ b/freemocap/gui/qt/freemocap_main.py
@@ -59,7 +59,7 @@ def qt_gui_main():
     sys.exit()
 
 
-def handle_pop_ups(freemocap_main_window):
+def handle_pop_ups(freemocap_main_window: MainWindow):
 
     if freemocap_main_window._gui_state.show_welcome_screen:
         freemocap_main_window.open_welcome_screen_dialog()

--- a/freemocap/gui/qt/main_window/freemocap_main_window.py
+++ b/freemocap/gui/qt/main_window/freemocap_main_window.py
@@ -146,6 +146,8 @@ class MainWindow(QMainWindow):
         self._control_panel_widget = self._create_control_panel_widget(log_update=self._log_view_widget.add_log)
         self._tools_dock_widget.setWidget(self._control_panel_widget)
 
+        self._connect_calibration_updates()
+
         log_view_dock_widget = QDockWidget("Log View", self)
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, log_view_dock_widget)
         log_view_dock_widget.setWidget(self._log_view_widget)
@@ -235,6 +237,8 @@ class MainWindow(QMainWindow):
             skellycam_widget=self._skellycam_widget, gui_state=self._gui_state, parent=self
         )
 
+        # TODO: connect calibration update signal here
+
         self._skelly_viewer_widget = SkellyViewer()
 
         center_tab_widget = CentralTabWidget(
@@ -272,6 +276,8 @@ class MainWindow(QMainWindow):
         self._process_motion_capture_data_panel.processing_finished_signal.connect(
             self._handle_processing_finished_signal
         )
+
+        # TODO: Connect calibration signal here, from calibration control panel
 
         self._visualization_control_panel = VisualizationControlPanel(parent=self, gui_state=self._gui_state)
         self._visualization_control_panel.export_to_blender_button.clicked.connect(
@@ -553,6 +559,10 @@ class MainWindow(QMainWindow):
         self._active_recording_info_widget.set_active_recording(
             recording_folder_path=Path(folder_to_save_videos).parent
         )
+
+    def _connect_calibration_updates(self):
+        self._process_motion_capture_data_panel._calibration_control_panel.control_panel_calibration_updated.connect(self._controller_group_box.charuco_option_updated)
+        self._controller_group_box.controller_group_box_calibration_updated.connect(self._process_motion_capture_data_panel._calibration_control_panel.charuco_option_updated)
 
     def reboot_gui(self):
         logger.info("Rebooting GUI... ")

--- a/freemocap/gui/qt/widgets/camera_controller_group_box.py
+++ b/freemocap/gui/qt/widgets/camera_controller_group_box.py
@@ -157,12 +157,12 @@ class CameraControllerGroupBox(QGroupBox):
         hbox_bottom = QHBoxLayout()
         hbox_bottom.setAlignment(Qt.AlignmentFlag.AlignLeft)
 
-        self._annotate_charuco_checkbox = QCheckBox("Display Charuco Overlay")
+        self._annotate_charuco_checkbox = QCheckBox("Display Charuco Overlay (requires camera restart)")
         self._annotate_charuco_checkbox.setChecked(self.gui_state.annotate_charuco_images)
         self._skellycam_widget.annotate_images = self._annotate_charuco_checkbox.isChecked()
         hbox_bottom.addWidget(self._annotate_charuco_checkbox)
 
-        self._use_charuco_as_groundplane_checkbox = QCheckBox("Use Charuco as groundplane")
+        self._use_charuco_as_groundplane_checkbox = QCheckBox("Use initial Charuco board position as groundplane origin")
         self._use_charuco_as_groundplane_checkbox.setChecked(self.gui_state.use_charuco_as_groundplane)
         hbox_bottom.addWidget(self._use_charuco_as_groundplane_checkbox)
 

--- a/freemocap/gui/qt/widgets/control_panel/calibration_control_panel.py
+++ b/freemocap/gui/qt/widgets/control_panel/calibration_control_panel.py
@@ -179,7 +179,7 @@ class CalibrationControlPanel(QWidget):
         hbox2.addLayout(self._charuco_square_size_form_layout)
 
         # Create checkbox
-        self._use_charuco_as_groundplane_checkbox = QCheckBox("Use Charuco board as groundplane")
+        self._use_charuco_as_groundplane_checkbox = QCheckBox("Use initial Charuco board position as groundplane origin")
         self._use_charuco_as_groundplane_checkbox.setToolTip(
             "Set the Charuco board's coordinate system as the global origin"
         )


### PR DESCRIPTION
Fixes #734 by changing the charuco groundplane (and overlay display) text, and syncs both the charuco board option and square size user inputs across the dfiferent widgets.

Currently it works, but the UI is messed up for entering the square size. It is casting the entry to a float while input is still being received, making it hard to input the correct number. I'll take a look at it again once I get to some more pressing tasks.