### PR TITLE
Update windows runner

### DIFF
--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The 1.7 release build action for the Windows installer is failing with this error:

```
The windows-2019 runner image is being deprecated, consider switching to windows-2022(windows-latest) or windows-2025 instead. For more details see https://github.com/actions/runner-images/issues/12045.
```

This PR updates to the suggested windows 2022 runner.