### PR TITLE
Update feature request template with design doc/rfc principles

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,14 +10,21 @@ assignees: ''
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
+What are the problems this is trying to solve? What is the motivation for the work? What is the scope of the change?
+
+What type of user is the change intended for? Does is affect animators, scientists, or some other group in particular?
+
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
+
+How will this change the usage of the software? Is it user facing, or internal? Does it need UI changes?
+
+**Detailed Design/Implementation**
+The nitty gritty of what you're proposing. What is the architecture? How is the problem being solved? Include schemas for classes, description of the interface, api methods... Also a good chance to hash out names/ontologies. This stuff takes time to rework, so the more detail here can prevent expensive rewrites
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
 
-**What is the use case for this feature?**
-For example, will it help with your scientific data collection or make animating characters from the data easier?
 
 **Additional context**
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This PR updates our feature request template to fit in with the design doc/RFC principles discussed here: https://github.com/freemocap/freemocap_foundation/issues/39#issue-3526659286

I merged the proposed template from the issue with the existing one. Feel free to change it if it doesn't read well.