### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/coverage-testing.yml
+++ b/.github/workflows/coverage-testing.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Free up disk space

--- a/.github/workflows/diagnostics_calibration.yml
+++ b/.github/workflows/diagnostics_calibration.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -66,13 +66,13 @@ jobs:
           source .venv/bin/activate || source .venv/Scripts/activate
           python freemocap/diagnostics/calibration/calculate_calibration_diagnostics.py
       
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: data_current_calibration_${{ runner.os }}
           path: data_current_calibration.csv
 
       - name: Upload OS-specific calibration
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test_data_calibration_files${{ matrix.os }}
           path: |
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -99,7 +99,7 @@ jobs:
           uv pip install pandas plotly==5.* jinja2 packaging
 
       - name: Download OS calibration data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: data_current_calibration_*
           path: collected
@@ -111,13 +111,13 @@ jobs:
           python freemocap/diagnostics/calibration/merge_calibration_data.py
 
       - name: Upload calibration report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: calibration_diagnostics_report
           path: freemocap/diagnostics/calibration_diagnostics.html
 
       - name: Upload summary csv
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: calibration_diagnostics_csv
           path: freemocap/diagnostics/diagnostic_data/calibration_diagnostics_summary.csv

--- a/.github/workflows/flit_publish_to_pypi.yml
+++ b/.github/workflows/flit_publish_to_pypi.yml
@@ -21,11 +21,11 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.github/workflows/lint_actions_zizmor.yml
+++ b/.github/workflows/lint_actions_zizmor.yml
@@ -14,7 +14,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/linting-flake8.yml
+++ b/.github/workflows/linting-flake8.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Set up Python 3.x

--- a/.github/workflows/linux_installer.yml
+++ b/.github/workflows/linux_installer.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: System Info
@@ -19,7 +19,7 @@ jobs:
           gcc --version || true
           env
       - name: Set up Python 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.11'
@@ -57,7 +57,7 @@ jobs:
           cd ${{ github.workspace }}
           mv ${{ github.workspace }}/bin/pyapp freemocap_app && chmod +x freemocap_app
           tar -czvf freemocap_app.tar.gz freemocap_app
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: freemocap_linux_app
           path: freemocap_app.tar.gz

--- a/.github/workflows/mac_installer.yml
+++ b/.github/workflows/mac_installer.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: macos-13
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: System Info
@@ -18,7 +18,7 @@ jobs:
           gcc --version || true
           env
       - name: Set up Python 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.11'
@@ -64,7 +64,7 @@ jobs:
           cp ${{ github.workspace }}/freemocap/assets/mac_app_files/freemocap.icns ${{ github.workspace }}/freemocap.app/Contents/Resources
           cp ${{ github.workspace }}/freemocap/assets/mac_app_files/Info.plist ${{ github.workspace }}/freemocap.app/Contents
           tar -czvf freemocap.tar.gz freemocap.app
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: freemocap_mac_app
           path: freemocap.tar.gz

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -14,11 +14,11 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing - https://docs.pypi.org/trusted-publishers/using-a-publisher/
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -31,7 +31,7 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Cache Poetry dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pypoetry
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: System Info
@@ -21,7 +21,7 @@ jobs:
           gcc --version || true
           env
       - name: Set up Python 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.10'

--- a/.github/workflows/version-testing-1.yml
+++ b/.github/workflows/version-testing-1.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Free up disk space

--- a/.github/workflows/version-testing-2.yml
+++ b/.github/workflows/version-testing-2.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Free up disk space

--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: System Info
@@ -17,7 +17,7 @@ jobs:
           systeminfo || true
           env
       - name: Set up Python 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.11'
@@ -68,7 +68,7 @@ jobs:
       - name: Set Executable Icon
         run: |
           rcedit "freemocap_app.exe" --set-icon "${{ github.workspace }}/freemocap/assets/logo/freemocap_skelly_logo.ico"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: freemocap_windows_exe
           path: freemocap_app.exe


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v2`](https://github.com/actions/cache/releases/tag/v2) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | publish_to_pypi.yml |
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | coverage-testing.yml, diagnostics_calibration.yml, flit_publish_to_pypi.yml, lint_actions_zizmor.yml, linting-flake8.yml, linux_installer.yml, mac_installer.yml, publish_to_pypi.yml, python-testing.yml, version-testing-1.yml, version-testing-2.yml, windows_installer.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | diagnostics_calibration.yml |
| `actions/setup-python` | [`v4`](https://github.com/actions/setup-python/releases/tag/v4) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | diagnostics_calibration.yml, flit_publish_to_pypi.yml, linux_installer.yml, mac_installer.yml, publish_to_pypi.yml, python-testing.yml, windows_installer.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | diagnostics_calibration.yml, linux_installer.yml, mac_installer.yml, windows_installer.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/cache** (v2 → v5):
  - ⚠️ v4 uses a new caching backend - existing caches may not be reused on first run

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
