### PR TITLE
fix: correct Path.exists() calls and rigid bone enforcement bugs

### DIFF
--- a/freemocap/core_processes/post_process_skeleton_data/enforce_rigid_bones.py
+++ b/freemocap/core_processes/post_process_skeleton_data/enforce_rigid_bones.py
@@ -69,14 +69,14 @@ def enforce_rigid_bones(
         proximal_marker, distal_marker = segment.proximal, segment.distal
 
         for frame_index, current_length in enumerate(lengths):
-            if current_length != desired_length:
+            if not np.isclose(current_length, desired_length):
                 proximal_position = marker_data[proximal_marker][frame_index]
                 distal_position = marker_data[distal_marker][frame_index]
                 direction = distal_position - proximal_position
-                try:
-                    direction /= np.linalg.norm(direction)  # Normalize to unit vector
-                except ZeroDivisionError:
-                    direction /= 1e-5  # Set to a small value if the direction is zero
+                norm = np.linalg.norm(direction)
+                if norm < 1e-10:
+                    continue
+                direction /= norm
                 adjustment = (desired_length - current_length) * direction
 
                 rigid_marker_data[distal_marker][frame_index] += adjustment

--- a/freemocap/system/paths_and_filenames/path_getters.py
+++ b/freemocap/system/paths_and_filenames/path_getters.py
@@ -254,7 +254,7 @@ def get_timestamps_directory(recording_directory: Union[str, Path]) -> Optional[
 # TODO: figure out how to deal with different file prefixes for all of these below
 def get_raw_skeleton_npy_file_name(data_folder_name: Union[str, Path]) -> str:
     raw_data_subfolder_path = Path(data_folder_name) / RAW_DATA_FOLDER_NAME
-    if raw_data_subfolder_path.exists:
+    if raw_data_subfolder_path.exists():
         raw_data_npy_path_list = [path.name for path in raw_data_subfolder_path.glob("*.npy")]
         if RAW_3D_NPY_FILE_NAME in raw_data_npy_path_list:
             return str(raw_data_subfolder_path / RAW_3D_NPY_FILE_NAME)
@@ -271,7 +271,7 @@ def get_full_npy_file_path(output_data_folder: Union[str, Path]) -> str:
 
 def get_total_body_center_of_mass_file_path(output_data_folder: Union[str, Path]) -> str:
     center_of_mass_subfolder_path = Path(output_data_folder) / CENTER_OF_MASS_FOLDER_NAME
-    if center_of_mass_subfolder_path.exists:
+    if center_of_mass_subfolder_path.exists():
         center_of_mass_npy_path_list = [path.name for path in center_of_mass_subfolder_path.glob("*.npy")]
 
         if TOTAL_BODY_CENTER_OF_MASS_NPY_FILE_NAME in center_of_mass_npy_path_list:
@@ -282,7 +282,7 @@ def get_total_body_center_of_mass_file_path(output_data_folder: Union[str, Path]
 
 def get_image_tracking_data_file_name(data_folder_name: Union[str, Path]) -> str:
     raw_data_subfolder_path = Path(data_folder_name) / RAW_DATA_FOLDER_NAME
-    if raw_data_subfolder_path.exists:
+    if raw_data_subfolder_path.exists():
         raw_data_npy_path_list = [path.name for path in raw_data_subfolder_path.glob("*.npy")]
 
         if DATA_2D_NPY_FILE_NAME in raw_data_npy_path_list:
@@ -293,7 +293,7 @@ def get_image_tracking_data_file_name(data_folder_name: Union[str, Path]) -> str
 
 def get_reprojection_error_file_path(data_folder_name: Union[str, Path]) -> str:
     raw_data_subfolder_path = Path(data_folder_name) / RAW_DATA_FOLDER_NAME
-    if raw_data_subfolder_path.exists:
+    if raw_data_subfolder_path.exists():
         raw_data_npy_path_list = [path.name for path in raw_data_subfolder_path.glob("*.npy")]
 
         if REPROJECTION_ERROR_NPY_FILE_NAME in raw_data_npy_path_list:


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs found during code review:

### 1. `Path.exists` called without parentheses — always evaluates to `True`

**File:** `freemocap/system/paths_and_filenames/path_getters.py` (lines 257, 274, 285, 296)

`Path.exists` without `()` returns the bound method object, which is always truthy. This means the directory-existence checks in `get_raw_skeleton_npy_file_name()`, `get_total_body_center_of_mass_file_path()`, `get_image_tracking_data_file_name()`, and `get_reprojection_error_file_path()` never detect missing directories — they always fall through to the file-glob logic, which then fails with a confusing error instead of the intended exception.

**Fix:** Changed `.exists` → `.exists()` on all four occurrences.

### 2. Wrong exception type in `enforce_rigid_bones` — NaN propagation bug

**File:** `freemocap/core_processes/post_process_skeleton_data/enforce_rigid_bones.py` (lines 71-84)

Two issues:
- **Wrong exception caught:** The code catches `ZeroDivisionError`, but NumPy never raises this exception — it silently produces `inf`/`nan` values. The except block never executes, so zero-length bone directions produce `[nan, nan, nan]` that propagate through the entire kinematic chain.
- **Float equality comparison:** `current_length != desired_length` compares floats with `!=`, which almost never evaluates to `False` due to floating-point precision, causing unnecessary adjustment computation on every single frame.

**Fix:**
- Replaced the try/except with an explicit `np.linalg.norm()` check: if `norm < 1e-10`, skip the degenerate frame
- Replaced `!=` with `np.isclose()` to properly handle floating-point comparison