### PR TITLE
fix: resolve CPU busy-spin, mutable default metadata, and rigid bone data corruption

### DIFF
--- a/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/freemocap_anipose.py
+++ b/freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/freemocap_anipose.py
@@ -814,9 +814,9 @@ class FisheyeCamera(Camera):
 
 
 class CameraGroup:
-    def __init__(self, cameras, metadata={}):
+    def __init__(self, cameras, metadata=None):
         self.cameras = cameras
-        self.metadata = metadata
+        self.metadata = metadata if metadata is not None else {}
         self.charuco_2d_data = None
 
     def subset_cameras(self, indices):

--- a/freemocap/core_processes/post_process_skeleton_data/enforce_rigid_bones.py
+++ b/freemocap/core_processes/post_process_skeleton_data/enforce_rigid_bones.py
@@ -69,14 +69,14 @@ def enforce_rigid_bones(
         proximal_marker, distal_marker = segment.proximal, segment.distal
 
         for frame_index, current_length in enumerate(lengths):
-            if current_length != desired_length:
-                proximal_position = marker_data[proximal_marker][frame_index]
-                distal_position = marker_data[distal_marker][frame_index]
+            if not np.isclose(current_length, desired_length):
+                proximal_position = rigid_marker_data[proximal_marker][frame_index]
+                distal_position = rigid_marker_data[distal_marker][frame_index]
                 direction = distal_position - proximal_position
-                try:
-                    direction /= np.linalg.norm(direction)  # Normalize to unit vector
-                except ZeroDivisionError:
-                    direction /= 1e-5  # Set to a small value if the direction is zero
+                norm = np.linalg.norm(direction)
+                if norm < 1e-10:
+                    continue
+                direction /= norm
                 adjustment = (desired_length - current_length) * direction
 
                 rigid_marker_data[distal_marker][frame_index] += adjustment

--- a/freemocap/gui/qt/widgets/log_view_widget.py
+++ b/freemocap/gui/qt/widgets/log_view_widget.py
@@ -1,5 +1,6 @@
 import logging
 import multiprocessing
+import queue
 import threading
 from logging.handlers import QueueHandler
 from queue import Queue
@@ -41,12 +42,12 @@ class LoggingQueueListener(QThread):
         logger.info("Starting LoggingQueueListener thread")
         try:
             while not self._exit_event.is_set():
-                if self._logging_queue.empty():
+                try:
+                    record = self._logging_queue.get(block=True, timeout=0.1)
+                except queue.Empty:
                     if self._parent._keep_logging:
                         QtCore.QMetaObject.invokeMethod(self._parent, "log_progress", QtCore.Qt.QueuedConnection)
                     continue
-
-                record = self._logging_queue.get(block=True)
 
                 if record is None:
                     break
@@ -88,14 +89,24 @@ class LogViewWidget(QPlainTextEdit):
         self._logging_queue_listener.start()
 
     def add_log(self, record: logging.LogRecord):
-        level = record.levelname.ljust(7)  # 7 characters long, right padded with spaces
-        timestamp = f"[{record.asctime}.{record.msecs:04.0f}]".ljust(24)  # 24 characters long
-        process_id_str = f"{record.process}".rjust(6)  # 5 characters long, left padded with spaces
-        thread_id_str = f"{record.thread}".rjust(6)  # 5 characters long, left padded with spaces
-        full_message = record.getMessage().split(":::::")[-1].strip()
-        message_content = full_message.split("||||")[-1].strip()
-        code_path_str = full_message.split("||||")[0].strip()
-        package, method, line = code_path_str.split(":")
+        if not isinstance(record, logging.LogRecord):
+            return
+
+        try:
+            level = record.levelname.ljust(7)
+            timestamp = f"[{record.asctime}.{record.msecs:04.0f}]".ljust(24)
+            process_id_str = f"{record.process}".rjust(6)
+            thread_id_str = f"{record.thread}".rjust(6)
+            full_message = record.getMessage().split(":::::")[-1].strip()
+            message_content = full_message.split("||||")[-1].strip()
+            code_path_str = full_message.split("||||")[0].strip()
+            parts = code_path_str.split(":")
+            if len(parts) == 3:
+                package, method, line = parts
+            else:
+                package, method, line = code_path_str, "", ""
+        except Exception:
+            return
 
         if message_content == LOG_VIEW_PROGRESS_BAR_STRING + ".":
             self._keep_logging = True


### PR DESCRIPTION
## Summary

Three high-impact fixes addressing CPU waste, calibration data corruption, and incorrect biomechanical output.

### 1. LoggingQueueListener busy-spins at 100% CPU during processing

**File:** `freemocap/gui/qt/widgets/log_view_widget.py`

The `LoggingQueueListener.run()` loop checked `self._logging_queue.empty()` and immediately called `continue` with no sleep or blocking when the queue was empty. This created a tight busy-wait loop that pegged one CPU core at 100% for the entire duration of any processing operation. Additionally, `QMetaObject.invokeMethod(log_progress)` was called on every iteration, flooding the Qt event queue.

**Fix:** Replaced the polling pattern with `queue.get(block=True, timeout=0.1)` + `queue.Empty` exception handling.

**Bonus:** Hardened `add_log()` against malformed/non-LogRecord objects from the child process, and against log messages with unexpected format (the `split(":")` assumed exactly 3 parts).

### 2. Mutable default `metadata={}` in CameraGroup causes cross-instance calibration data corruption

**File:** `freemocap/core_processes/capture_volume_calibration/anipose_camera_calibration/freemocap_anipose.py` (line 817)

The default `{}` is shared across all instances created without explicit metadata. Calibration writes charuco_square_size, timestamps, video paths into this dict. Subsequent CameraGroup instances from `from_dicts()` or `from_names()` silently inherited stale metadata.

**Fix:** Changed to `metadata=None` with `self.metadata = metadata if metadata is not None else {}`.

### 3. `enforce_rigid_bones` reads stale pre-adjustment positions, producing incorrect skeleton output

**File:** `freemocap/core_processes/post_process_skeleton_data/enforce_rigid_bones.py`

Three interrelated bugs:
- **Stale data reads:** Read proximal/distal from original `marker_data` but wrote to `rigid_marker_data` copy. Child segment adjustments used pre-adjustment parent positions.
- **Wrong exception type:** Caught `ZeroDivisionError` but NumPy produces `NaN` silently, so the except block was dead code.
- **Float equality:** `!=` on floats caused the adjustment loop to run every frame.

**Fix:** Read from `rigid_marker_data`, explicit norm check, `np.isclose()`.