### PR TITLE
Publish dummy skeleton when ring buffer doesn't have images

### DIFF
--- a/freemocap/core/pipeline/realtime/realtime_skeleton_inference_node.py
+++ b/freemocap/core/pipeline/realtime/realtime_skeleton_inference_node.py
@@ -221,7 +221,15 @@ class RealtimeSkeletonInferenceNode(SourceNode):
                     timer.record("frame_read", (time.perf_counter() - t_read) * 1e3)
 
                 if not images:
-                    # Ring buffer didn't have the frame for any camera; skip.
+                    # Ring buffer didn't have the frame for any camera (e.g.
+                    # overwritten during slow init). Publish a null result so the
+                    # aggregator doesn't hang waiting for a result that never comes.
+                    skeleton_result_pub.put(
+                        SkeletonInferenceResultMessage(
+                            frame_number=requested_frame_number,
+                            per_camera_skeleton={cam_id: None for cam_id in camera_ids},
+                        ),
+                    )
                     continue
 
                 # ---- Batched skeleton inference ----


### PR DESCRIPTION
This change fixed the hang in realtime. Essentially start up was too slow, and the frontend got stuck without an image. Passing a dummy skeleton instead of skipping helps it leave that state and lets realtime run properly