### PR TITLE
Aaron/filtering UI updates

### DIFF
--- a/freemocap-ui/src/components/mocap-setup/mocap-postprocess-settings.tsx
+++ b/freemocap-ui/src/components/mocap-setup/mocap-postprocess-settings.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
+import {
+    posthocFilterConfigUpdated,
+    selectPosthocFilterConfig
+} from "@/store/slices/mocap";
+
+import ValueSelector from "@/components/ui-components/ValueSelector"
+import SubactionHeader from "../ui-components/SubactionHeader";
+
+const PosthocFilterSettings:React.FC = () => {
+    const dispatch = useAppDispatch();
+    const config = useAppSelector(selectPosthocFilterConfig)
+    const maximumCutoff = Math.max(
+        0.1,
+        config.sampling_rate/2 - 0.1
+    );
+
+    return (
+        <div className = "flex flex-col gap-1">
+            <SubactionHeader text = "Butterworth Low-Pass Filter" />
+
+            <p className = "text sm text-gray">
+                Method: Butterworth low-pass
+            </p>
+
+            <div className = "flex flex-row items-center justify-content-space-between">
+                <span className = "text sm"> Sampling Rate </span>
+                <ValueSelector
+                    value = {config.sampling_rate}
+                    min = {1.0}
+                    max = {1200.0}
+                    step = {1}
+                    unit = "Hz"
+                    onChange = {(sampling_rate) => {
+                        const newMaximumCutoff = Math.max(
+                            0.1,
+                            sampling_rate/2 - 0.1,
+                        );
+
+                        dispatch(
+                            posthocFilterConfigUpdated({
+                                sampling_rate,
+                                cutoff: Math.min(
+                                    config.cutoff,
+                                    newMaximumCutoff
+                                ),
+                            }),
+                        );
+                    }}
+                />
+            </div>
+
+            <div className = "flex flex-row items-center justify-content-space-between">
+                <span className = "text sm"> Cutoff (Hz)</span>
+
+                <ValueSelector 
+                    value = {config.cutoff}
+                    min = {0}
+                    max = {maximumCutoff}
+                    step = {1}
+                    unit = "Hz"
+                    onChange = {(cutoff) => 
+                        dispatch(
+                            posthocFilterConfigUpdated({cutoff})
+                        )
+                    }
+                    />
+            </div>
+
+            <div className="flex flex-row items-center justify-content-space-between">
+                <span className="text sm">Order</span>
+
+                <ValueSelector
+                    value={config.order}
+                    min={1}
+                    max={100}
+                    step={1}
+                    unit=""
+                    onChange={(order) =>
+                        dispatch(
+                            posthocFilterConfigUpdated({order}),
+                        )
+                    }
+                />
+            </div>
+        </div>
+    );
+};
+
+export default PosthocFilterSettings;

--- a/freemocap-ui/src/components/mocap-setup/mocap-setup-modal.tsx
+++ b/freemocap-ui/src/components/mocap-setup/mocap-setup-modal.tsx
@@ -4,7 +4,7 @@ import SubactionHeader from "@/components/ui-components/SubactionHeader";
 
 import ProcessingDirectorySettings from "@/components/mocap-setup/mocap-processing-directory";
 import CalibrationModule from "@/components/pipeline-progress/calibration-progress/calibration-module";
-import MOCAPthreeDReconstructionSettings from "@/components/mocap-setup/mocap-3dreconstruction-settings";
+import PosthocFilterSettings from "@/components/mocap-setup/mocap-postprocess-settings";
 import MOCAPDetectorSettings from "@/components/mocap-setup/mocap-detector-settings";
 import MOCAPBlenderSettings from "@/components/mocap-setup/mocap-blender-settings";
 import { useMocap } from "@/hooks/useMocap";
@@ -137,16 +137,16 @@ const MocapSetupModal: React.FC<MocapSetupModalProps> = ({
               onClick={() => scrollToPanel(1)}
             />
             <ButtonSm
-              text="3D Reconstruction"
-              buttonType={activeButton === "button3" ? "activated" : "idle"}
-              className="full-width quaternary"
-              onClick={() => scrollToPanel(2)}
-            />
-            <ButtonSm
               text="Detector"
               buttonType={activeButton === "button4" ? "activated" : "idle"}
               className="full-width quaternary"
               onClick={() => scrollToPanel(3)}
+            />
+            <ButtonSm
+              text="3D Reconstruction"
+              buttonType={activeButton === "button3" ? "activated" : "idle"}
+              className="full-width quaternary"
+              onClick={() => scrollToPanel(2)}
             />
             <ButtonSm
               text="Blender"
@@ -182,25 +182,22 @@ const MocapSetupModal: React.FC<MocapSetupModalProps> = ({
               />
             </div>
 
-            {/* Panel 3 - 3D Reconstruction */}
+            {/* Panel 3 - Detector */}
             <div
               ref={panel3Ref}
               data-panel="panel3"
               className="bg-secondary p-2 br-1"
             >
-              <MOCAPthreeDReconstructionSettings
-                open={true}
-                onClose={() => {}}
-              />
+              <MOCAPDetectorSettings open={true} onClose={() => {}} />
             </div>
 
-            {/* Panel 4 - Detector */}
+            {/* Panel 4 - 3D Reconstruction */}
             <div
               ref={panel4Ref}
               data-panel="panel4"
               className="bg-secondary p-2 br-1"
             >
-              <MOCAPDetectorSettings open={true} onClose={() => {}} />
+              <PosthocFilterSettings />
             </div>
 
             {/* Panel 5 - Blender */}

--- a/freemocap-ui/src/components/ui-components/ValueSelector.tsx
+++ b/freemocap-ui/src/components/ui-components/ValueSelector.tsx
@@ -39,6 +39,7 @@ const InputWithUnit: React.FC<InputWithUnitProps> = ({value, onChange, unit = ""
                 disabled={disabled}
                 onChange={e => onChange(Math.max(min, Math.min(max, Number(e.target.value) || min)))}
                 onFocus={e => e.target.select()}
+                onClick={e => e.currentTarget.select()}
                 onKeyDown={handleKeyDown}
                 className="input-field text md w-full text-center"
             />

--- a/freemocap-ui/src/store/slices/mocap/mocap-slice.ts
+++ b/freemocap-ui/src/store/slices/mocap/mocap-slice.ts
@@ -45,6 +45,13 @@ export interface EstimatorConfig {
     iqr_confidence_sensitivity: number;
 }
 
+export interface PosthocFilterConfig {
+    method: "butter_low_pass";
+    cutoff: number;
+    sampling_rate: number;
+    order: number;
+}
+
 /**
  * Mirrors backend RealtimeFilterConfig (skeleton smoothing + gating).
  * Field names use snake_case to match the backend JSON.
@@ -86,6 +93,7 @@ export const RTMPOSE_MODELS: { label: string; value: RTMPoseModelName }[] = [
 export interface MocapConfig {
     detector: MediapipeDetectorConfig;
     skeleton_filter: RealtimeFilterConfig;
+    posthoc_filter: PosthocFilterConfig;
     detectorType: DetectorType;
     rtmPoseModelName: RTMPoseModelName;
     rtmPoseConfidenceThreshold: number;
@@ -164,6 +172,7 @@ export function detectPreset(
  *   Range 0.003–0.02 is appropriate for mm-space data.
  *   NOTE: beta = 0.3 (meter-space convention) is ~1000× too high.
  */
+
 export const DEFAULT_REALTIME_FILTER_CONFIG: RealtimeFilterConfig = {
     min_cutoff: 1.0,
     beta: 0.007,
@@ -180,6 +189,15 @@ export const DEFAULT_REALTIME_FILTER_CONFIG: RealtimeFilterConfig = {
     prediction_velocity_decay: 0.75,
 };
 
+export const DEFAULT_POSTHOC_FILTER_CONFIG: PosthocFilterConfig ={
+    method: "butter_low_pass",
+    cutoff: 6.0,
+    sampling_rate: 30.0,
+    order: 4,
+};
+
+
+ 
 export interface MocapDirectoryInfo {
     exists: boolean;
     canRecord: boolean;
@@ -204,24 +222,49 @@ export interface MocapState {
     processingPhase: string;
 }
 
+
+const DEFAULT_MOCAP_CONFIG: MocapConfig = {
+    detector: {...MEDIAPIPE_REALTIME_PRESET},
+    skeleton_filter: {...DEFAULT_REALTIME_FILTER_CONFIG},
+    posthoc_filter: {...DEFAULT_POSTHOC_FILTER_CONFIG},
+
+    detectorType: "rtmpose",
+    rtmPoseModelName: "rtmw-x-l_256x192",
+    rtmPoseConfidenceThreshold: 0.004,
+    mediapipeModelComplexity: "heavy",
+    mediapipeDetectionConfidence: 0.5,
+    mediapipePresenceConfidence: 0.5,
+    mediapipeTrackingConfidence: 0.5,
+    mediapipeNumHands: 2,
+    mediapipeNumFaces: 1,
+};
+
 // ==================== Initial State ====================
 
-const _persistedMocapConfig = loadFromStorage<MocapConfig | null>('mocap.config', null);
+const _persistedMocapConfig = loadFromStorage<Partial<MocapConfig> | null>( "mocap.config", null, );
+
+const initialMocapConfig: MocapConfig = {
+    ...DEFAULT_MOCAP_CONFIG,
+    ...(_persistedMocapConfig ?? {}),
+
+    detector: {
+        ...DEFAULT_MOCAP_CONFIG.detector,
+        ...(_persistedMocapConfig?.detector ?? {}),
+    },
+
+    skeleton_filter: {
+        ...DEFAULT_MOCAP_CONFIG.skeleton_filter,
+        ...(_persistedMocapConfig?.skeleton_filter ?? {}),
+    },
+
+    posthoc_filter: {
+        ...DEFAULT_MOCAP_CONFIG.posthoc_filter,
+        ...(_persistedMocapConfig?.posthoc_filter ?? {}),
+    },
+};
 
 const initialState: MocapState = {
-    config: _persistedMocapConfig ?? {
-        detector: { ...MEDIAPIPE_REALTIME_PRESET },
-        skeleton_filter: { ...DEFAULT_REALTIME_FILTER_CONFIG },
-        detectorType: "rtmpose" as DetectorType,
-        rtmPoseModelName: "rtmw-x-l_256x192" as RTMPoseModelName,
-        rtmPoseConfidenceThreshold: 0.004,
-        mediapipeModelComplexity: "heavy" as MediapipeModelComplexity,
-        mediapipeDetectionConfidence: 0.5,
-        mediapipePresenceConfidence: 0.5,
-        mediapipeTrackingConfidence: 0.5,
-        mediapipeNumHands: 2,
-        mediapipeNumFaces: 1,
-    },
+    config: initialMocapConfig,
     isRecording: false,
     recordingProgress: 0,
     isLoading: false,
@@ -229,7 +272,7 @@ const initialState: MocapState = {
     directoryInfo: null,
     calibrationTomlPath: null,
     processingProgress: 0,
-    processingPhase: '',
+    processingPhase: "",
 };
 
 // ==================== Slice ====================
@@ -294,6 +337,10 @@ export const mocapSlice = createSlice({
         /** Partially update individual skeleton filter fields. */
         skeletonFilterConfigUpdated: (state, action: PayloadAction<Partial<RealtimeFilterConfig>>) => {
             state.config.skeleton_filter = { ...state.config.skeleton_filter, ...action.payload };
+        },
+
+        posthocFilterConfigUpdated: (state, action: PayloadAction<Partial<PosthocFilterConfig>>) => {
+            state.config.posthoc_filter = {...state.config.posthoc_filter, ...action.payload};
         },
 
         mocapProgressUpdated: (state, action: PayloadAction<number>) => {
@@ -383,6 +430,7 @@ export const selectMocap = (state: RootState) => state.mocap;
 export const selectMocapConfig = (state: RootState) => state.mocap.config;
 export const selectMocapDetectorConfig = (state: RootState) => state.mocap.config.detector;
 export const selectSkeletonFilterConfig = (state: RootState) => state.mocap.config.skeleton_filter;
+export const selectPosthocFilterConfig = (state: RootState) => state.mocap.config.posthoc_filter;
 export const selectMocapDetectorType = (state: RootState) => state.mocap.config.detectorType;
 export const selectMocapRtmPoseModelName = (state: RootState) => state.mocap.config.rtmPoseModelName;
 export const selectMocapRtmPoseConfidenceThreshold = (state: RootState) => state.mocap.config.rtmPoseConfidenceThreshold;
@@ -454,6 +502,7 @@ export const {
     mocapDetectorConfigUpdated,
     skeletonFilterConfigReplaced,
     skeletonFilterConfigUpdated,
+    posthocFilterConfigUpdated,
     mocapProgressUpdated,
     mocapErrorCleared,
     mocapDirectoryInfoUpdated,

--- a/freemocap-ui/src/store/slices/mocap/mocap-thunks.ts
+++ b/freemocap-ui/src/store/slices/mocap/mocap-thunks.ts
@@ -23,6 +23,7 @@ function buildPosthocConfig(state: RootState) {
         mediapipeNumHands: config.mediapipeNumHands,
         mediapipeNumFaces: config.mediapipeNumFaces,
         calibrationTomlPath,
+        filterConfig: config.posthoc_filter,
         exportToBlender: blender.exportToBlenderEnabled,
         blenderExePath: blender.blenderExePath ?? blender.detectedBlenderExePath,
         autoOpenBlendFile: blender.autoOpenBlendFile,

--- a/freemocap/core/tasks/mocap/mocap_helpers/skeleton_from_mediapipe_observations.py
+++ b/freemocap/core/tasks/mocap/mocap_helpers/skeleton_from_mediapipe_observations.py
@@ -95,6 +95,7 @@ def skeleton_from_mediapipe_observation_recorders(
         config=interp_config,
     )
 
+    logger.info(f"Filtering trajectory with config: {filter_config.model_dump_json(indent=2)}")
     filtered_trajectory_3d: Trajectory3d = filter_trajectory(
         trajectory=interpolated_trajectory_3d,
         config=filter_config,

--- a/freemocap/core/tasks/mocap/mocap_task_config.py
+++ b/freemocap/core/tasks/mocap/mocap_task_config.py
@@ -22,6 +22,8 @@ from skellytracker.core.temporal_processing.temporal_processing_config import (
     KeypointsWithinBBoxRatioConfig,
 )
 
+from skellyforge.post_processing.filters.filter_config import FilterConfig
+
 
 
 class PosthocMocapPipelineConfig(BaseModel):
@@ -98,6 +100,13 @@ class PosthocMocapPipelineConfig(BaseModel):
         alias="calibrationTomlPath",
         description="Path to calibration TOML. If None, the most-recent successful calibration is used.",
     )
+
+    filter_config:FilterConfig = Field(
+        default=FilterConfig(),
+        alias = "filterConfig",
+        description="Configuration for the post-processing filter applied to the mocap data.",
+    )
+
     export_to_blender: bool = Field(
         default=True,
         alias="exportToBlender",

--- a/freemocap/core/tasks/mocap/posthoc_mocap_task.py
+++ b/freemocap/core/tasks/mocap/posthoc_mocap_task.py
@@ -108,6 +108,7 @@ def run_posthoc_mocap_aggregator_task(
         observation_recorders=observation_recorders,
         path_to_calibration_toml=calibration_toml_path,
         path_to_output_data_folder=output_folder,
+        filter_config=task_config.filter_config
     )
 
     # ---- Save tracker schema alongside outputs ----


### PR DESCRIPTION
<img width="736" height="701" alt="image" src="https://github.com/user-attachments/assets/baac635a-2987-4ca4-b498-beb181dba604" />

The filter options listed for posthoc reconstruction (one euro, fabrik, point gate) are actually only used for real-time, while the filter actually used in posthoc (the butterworth filter), was not exposed in the UI. I removed the vestigial filters from the post-hoc processing menus and replaced them with the butterworth filter. I also switched around the order of the panels/menus to go from detector -> 3d reconstruction just to match the flow of the pipeline. 

This should also close #818 