### PR TITLE
Expose outlier rejection options

### DIFF
--- a/freemocap-ui/src/components/control-panels/server-connection/useServerPanel.ts
+++ b/freemocap-ui/src/components/control-panels/server-connection/useServerPanel.ts
@@ -63,8 +63,7 @@ export function useServerPanel(): ServerPanelState {
     // Persisted UI state
     const [expanded, setExpanded] = useState(() => loadFromStorage(STORAGE_KEYS.PANEL_EXPANDED, false));
     const [selectedExePath, setSelectedExePath] = useState(() => loadFromStorage(STORAGE_KEYS.SELECTED_EXE_PATH, ''));
-    const [autoLaunchServer, setAutoLaunchServer] = useState(() => loadFromStorage(STORAGE_KEYS.AUTO_LAUNCH_SERVER, true));
-    const [autoConnectWs, setAutoConnectWs] = useState(() => loadFromStorage(STORAGE_KEYS.AUTO_CONNECT_WS, true));
+    const [autoLaunchServer, setAutoLaunchServer] = useState(() => import.meta.env.DEV ? false : loadFromStorage(STORAGE_KEYS.AUTO_LAUNCH_SERVER, true));    const [autoConnectWs, setAutoConnectWs] = useState(() => loadFromStorage(STORAGE_KEYS.AUTO_CONNECT_WS, true));
     const [serverHost, setServerHost] = useState(() => loadFromStorage(STORAGE_KEYS.SERVER_HOST, DEFAULT_HOST));
     const [serverPort, setServerPort] = useState(() => loadFromStorage(STORAGE_KEYS.SERVER_PORT, DEFAULT_PORT));
 

--- a/freemocap-ui/src/components/mocap-setup/mocap-setup-modal.tsx
+++ b/freemocap-ui/src/components/mocap-setup/mocap-setup-modal.tsx
@@ -7,6 +7,7 @@ import CalibrationModule from "@/components/pipeline-progress/calibration-progre
 import PosthocFilterSettings from "@/components/mocap-setup/mocap-postprocess-settings";
 import MOCAPDetectorSettings from "@/components/mocap-setup/mocap-detector-settings";
 import MOCAPBlenderSettings from "@/components/mocap-setup/mocap-blender-settings";
+import TriangulationSettings from "@/components/mocap-setup/mocap-triangulation-settings";
 import { useMocap } from "@/hooks/useMocap";
 
 type MocapMode = "recording" | "playback";
@@ -44,7 +45,7 @@ const MocapSetupModal: React.FC<MocapSetupModalProps> = ({
     return "Cannot process recording";
   }, [canProcessMocapRecording, isRecording, isLoading, mocapRecordingPath, directoryInfo, calibrationTomlPath]);
   const [activeButton, setActiveButton] = useState<
-    "button1" | "button2" | "button3" | "button4" | "button5"
+    "button1" | "button2" | "button3" | "button4" | "button5" | "button6"
   >("button1");
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -53,9 +54,10 @@ const MocapSetupModal: React.FC<MocapSetupModalProps> = ({
   const panel3Ref = useRef<HTMLDivElement>(null);
   const panel4Ref = useRef<HTMLDivElement>(null);
   const panel5Ref = useRef<HTMLDivElement>(null);
+  const panel6Ref = useRef<HTMLDivElement>(null);
 
   const scrollToPanel = useCallback((panelIndex: number) => {
-    const refs = [panel1Ref, panel2Ref, panel3Ref, panel4Ref, panel5Ref];
+    const refs = [panel1Ref, panel2Ref, panel3Ref, panel4Ref, panel5Ref, panel6Ref];
     const targetRef = refs[panelIndex];
     if (targetRef.current && scrollContainerRef.current) {
       targetRef.current.scrollIntoView({
@@ -64,12 +66,13 @@ const MocapSetupModal: React.FC<MocapSetupModalProps> = ({
         inline: "nearest",
       });
       setActiveButton(
-        ["button1", "button2", "button3", "button4", "button5"][panelIndex] as
+        ["button1", "button2", "button3", "button4", "button5", "button6"][panelIndex] as
           | "button1"
           | "button2"
           | "button3"
           | "button4"
-          | "button5",
+          | "button5"
+          | "button6",
       );
     }
   }, []);
@@ -86,6 +89,7 @@ const MocapSetupModal: React.FC<MocapSetupModalProps> = ({
             else if (id === "panel3") setActiveButton("button3");
             else if (id === "panel4") setActiveButton("button4");
             else if (id === "panel5") setActiveButton("button5");
+            else if (id === "panel6") setActiveButton("button6");
           }
         });
       },
@@ -96,7 +100,7 @@ const MocapSetupModal: React.FC<MocapSetupModalProps> = ({
       },
     );
 
-    const panels = [panel1Ref, panel2Ref, panel3Ref, panel4Ref, panel5Ref];
+    const panels = [panel1Ref, panel2Ref, panel3Ref, panel4Ref, panel5Ref, panel6Ref];
     panels.forEach((ref) => {
       if (ref.current) observer.observe(ref.current);
     });
@@ -142,17 +146,25 @@ const MocapSetupModal: React.FC<MocapSetupModalProps> = ({
               className="full-width quaternary"
               onClick={() => scrollToPanel(2)}
             />
+
             <ButtonSm
-              text="3D Reconstruction"
-              buttonType={activeButton === "button4" ? "activated" : "idle"}
-              className="full-width quaternary"
-              onClick={() => scrollToPanel(3)}
+              text = "3D Triangulation"
+              buttonType = {activeButton === "button4" ? "activated" : "idle"}
+              className = "full-width quaternary"
+              onClick = {() => scrollToPanel(3)}
             />
+
             <ButtonSm
-              text="Blender"
+              text="Post Processing"
               buttonType={activeButton === "button5" ? "activated" : "idle"}
               className="full-width quaternary"
               onClick={() => scrollToPanel(4)}
+            />
+            <ButtonSm
+              text="Blender"
+              buttonType={activeButton === "button6" ? "activated" : "idle"}
+              className="full-width quaternary"
+              onClick={() => scrollToPanel(5)}
             />
           </div>
 
@@ -191,19 +203,28 @@ const MocapSetupModal: React.FC<MocapSetupModalProps> = ({
               <MOCAPDetectorSettings open={true} onClose={() => {}} />
             </div>
 
-            {/* Panel 4 - 3D Reconstruction */}
+            {/* Panel 4 - Triangulation */}
             <div
               ref={panel4Ref}
               data-panel="panel4"
               className="bg-secondary p-2 br-1"
             >
-              <PosthocFilterSettings />
+              <TriangulationSettings />
             </div>
 
-            {/* Panel 5 - Blender */}
+            {/* Panel 5 - Post Processing */}
             <div
               ref={panel5Ref}
               data-panel="panel5"
+              className="bg-secondary p-2 br-1"
+            >
+              <PosthocFilterSettings />
+            </div>
+
+            {/* Panel 6 - Blender */}
+            <div
+              ref={panel6Ref}
+              data-panel="panel6"
               className="bg-secondary p-2 br-1"
             >
               <MOCAPBlenderSettings open={true} onClose={() => {}} />

--- a/freemocap-ui/src/components/mocap-setup/mocap-triangulation-settings.tsx
+++ b/freemocap-ui/src/components/mocap-setup/mocap-triangulation-settings.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
+import {
+    triangulationConfigUpdated,
+    selectMocapTriangulationConfig
+} from "@/store/slices/mocap";
+
+import ValueSelector from "@/components/ui-components/ValueSelector"
+import SubactionHeader from "../ui-components/SubactionHeader";
+import Checkbox from "../ui-components/Checkbox";
+
+const TriangulationSettings:React.FC = () => {
+    const dispatch = useAppDispatch();
+    const config = useAppSelector(selectMocapTriangulationConfig)
+
+    return (
+        <div className = "flex flex-col gap-1">
+            <SubactionHeader text = "Triangulation Settings" />
+
+        
+        <Checkbox
+        label="Use outlier rejection"
+        checked={config.use_outlier_rejection}
+        onChange={(event) =>
+            dispatch(
+            triangulationConfigUpdated({
+                use_outlier_rejection: event.target.checked,
+            })
+            )}
+    
+        />
+
+        <div className = "flex flex-row p-1 items-center justify-content-space-between">
+            <span className = "text sm"> Minimum Cameras for Triangulation </span>
+            <ValueSelector
+                value = {config.minimum_cameras_for_triangulation}
+                min = {2}
+                max = {100}
+                onChange = {(cutoff) =>
+                    dispatch(
+                        triangulationConfigUpdated({
+                            minimum_cameras_for_triangulation: cutoff,
+                        })
+                    )
+                }
+            />
+        </div>
+
+        <div className = "flex flex-row p-1 items-center justify-content-space-between">
+            <span className = "text sm"> Maximum Cameras to Drop </span>
+            <ValueSelector
+                value = {config.maximum_cameras_to_drop}
+                min = {0}
+                max = {100}
+                onChange = {(cutoff) =>
+                    dispatch(
+                        triangulationConfigUpdated({
+                            maximum_cameras_to_drop: cutoff,
+                        })
+                    )
+                }
+            />
+        </div>
+
+        <div className = "flex flex-row p-1 items-center justify-content-space-between">
+            <span className = "text sm"> Target Reprojection Error </span>
+            <ValueSelector
+                value = {config.target_reprojection_error}
+                min = {0.001}
+                max = {1.0}
+                step = {0.001}
+                onChange = {(target_reprojection_error) =>
+                    dispatch(
+                        triangulationConfigUpdated({target_reprojection_error})
+                    )
+                }
+            />
+        </div>
+    </div>  
+
+            
+    );
+
+}
+
+export default TriangulationSettings;

--- a/freemocap-ui/src/components/mocap-setup/mocap-triangulation-settings.tsx
+++ b/freemocap-ui/src/components/mocap-setup/mocap-triangulation-settings.tsx
@@ -76,7 +76,7 @@ const TriangulationSettings: React.FC = () => {
                     value={config.target_reprojection_error}
                     min={0.001}
                     max={1.0}
-                    step={0.001}
+                    step={0.01}
                     onChange={(target_reprojection_error) =>
                         dispatch(
                             triangulationConfigUpdated({target_reprojection_error})

--- a/freemocap-ui/src/components/mocap-setup/mocap-triangulation-settings.tsx
+++ b/freemocap-ui/src/components/mocap-setup/mocap-triangulation-settings.tsx
@@ -36,10 +36,10 @@ const TriangulationSettings:React.FC = () => {
                 value = {config.minimum_cameras_for_triangulation}
                 min = {2}
                 max = {100}
-                onChange = {(cutoff) =>
+                onChange = {(minimum_cameras_for_triangulation) =>
                     dispatch(
                         triangulationConfigUpdated({
-                            minimum_cameras_for_triangulation: cutoff,
+                            minimum_cameras_for_triangulation: minimum_cameras_for_triangulation,
                         })
                     )
                 }
@@ -52,10 +52,10 @@ const TriangulationSettings:React.FC = () => {
                 value = {config.maximum_cameras_to_drop}
                 min = {0}
                 max = {100}
-                onChange = {(cutoff) =>
+                onChange = {(maximum_cameras_to_drop) =>
                     dispatch(
                         triangulationConfigUpdated({
-                            maximum_cameras_to_drop: cutoff,
+                            maximum_cameras_to_drop: maximum_cameras_to_drop,
                         })
                     )
                 }

--- a/freemocap-ui/src/components/mocap-setup/mocap-triangulation-settings.tsx
+++ b/freemocap-ui/src/components/mocap-setup/mocap-triangulation-settings.tsx
@@ -1,86 +1,91 @@
 import React from "react";
-import { useAppDispatch, useAppSelector } from "@/store/hooks";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
 import {
     triangulationConfigUpdated,
     selectMocapTriangulationConfig
-} from "@/store/slices/mocap";
+} from "../../store/slices/mocap";
 
-import ValueSelector from "@/components/ui-components/ValueSelector"
+import ValueSelector from "../ui-components/ValueSelector";
+import ToggleComponent from "../ui-components/ToggleComponent";
 import SubactionHeader from "../ui-components/SubactionHeader";
-import Checkbox from "../ui-components/Checkbox";
 
-const TriangulationSettings:React.FC = () => {
+const TriangulationSettings: React.FC = () => {
     const dispatch = useAppDispatch();
-    const config = useAppSelector(selectMocapTriangulationConfig)
+    const config = useAppSelector(selectMocapTriangulationConfig);
 
     return (
-        <div className = "flex flex-col gap-1">
-            <SubactionHeader text = "Triangulation Settings" />
+        <div className="flex flex-col gap-1">
+            <SubactionHeader text="Triangulation Settings" />
 
-        
-        <Checkbox
-        label="Use outlier rejection"
-        checked={config.use_outlier_rejection}
-        onChange={(event) =>
-            dispatch(
-            triangulationConfigUpdated({
-                use_outlier_rejection: event.target.checked,
-            })
-            )}
-    
-        />
-
-        <div className = "flex flex-row p-1 items-center justify-content-space-between">
-            <span className = "text sm"> Minimum Cameras for Triangulation </span>
-            <ValueSelector
-                value = {config.minimum_cameras_for_triangulation}
-                min = {2}
-                max = {100}
-                onChange = {(minimum_cameras_for_triangulation) =>
+            <ToggleComponent
+                text="Use outlier rejection"
+                isToggled={config.use_outlier_rejection}
+                onToggle={(checked) =>
                     dispatch(
                         triangulationConfigUpdated({
-                            minimum_cameras_for_triangulation: minimum_cameras_for_triangulation,
+                            use_outlier_rejection: checked,
                         })
                     )
                 }
             />
-        </div>
 
-        <div className = "flex flex-row p-1 items-center justify-content-space-between">
-            <span className = "text sm"> Maximum Cameras to Drop </span>
-            <ValueSelector
-                value = {config.maximum_cameras_to_drop}
-                min = {0}
-                max = {100}
-                onChange = {(maximum_cameras_to_drop) =>
-                    dispatch(
-                        triangulationConfigUpdated({
-                            maximum_cameras_to_drop: maximum_cameras_to_drop,
-                        })
-                    )
-                }
-            />
-        </div>
+            <div className={`flex flex-row p-1 items-center justify-content-space-between ${config.use_outlier_rejection ? '' : 'disabled'}`}>
+                <div className="flex items-center gap-1 flex-wrap">
+                    <span className="icon icon-size-20 subcat-icon"></span>
+                    <span className="text sm"> Minimum Cameras for Triangulation </span>
+                </div>
+                <ValueSelector
+                    value={config.minimum_cameras_for_triangulation}
+                    min={2}
+                    max={100}
+                    onChange={(minimum_cameras_for_triangulation) =>
+                        dispatch(
+                            triangulationConfigUpdated({
+                                minimum_cameras_for_triangulation: minimum_cameras_for_triangulation,
+                            })
+                        )
+                    }
+                />
+            </div>
 
-        <div className = "flex flex-row p-1 items-center justify-content-space-between">
-            <span className = "text sm"> Target Reprojection Error </span>
-            <ValueSelector
-                value = {config.target_reprojection_error}
-                min = {0.001}
-                max = {1.0}
-                step = {0.001}
-                onChange = {(target_reprojection_error) =>
-                    dispatch(
-                        triangulationConfigUpdated({target_reprojection_error})
-                    )
-                }
-            />
-        </div>
-    </div>  
+            <div className={`flex flex-row p-1 items-center justify-content-space-between ${config.use_outlier_rejection ? '' : 'disabled'}`}>
+                <div className="flex items-center gap-1 flex-wrap">
+                    <span className="icon icon-size-20 subcat-icon"></span>
+                    <span className="text sm"> Maximum Cameras to Drop </span>
+                </div>
+                <ValueSelector
+                    value={config.maximum_cameras_to_drop}
+                    min={0}
+                    max={100}
+                    onChange={(maximum_cameras_to_drop) =>
+                        dispatch(
+                            triangulationConfigUpdated({
+                                maximum_cameras_to_drop: maximum_cameras_to_drop,
+                            })
+                        )
+                    }
+                />
+            </div>
 
-            
+            <div className={`flex flex-row p-1 items-center justify-content-space-between ${config.use_outlier_rejection ? '' : 'disabled'}`}>
+                <div className="flex items-center gap-1 flex-wrap">
+                    <span className="icon icon-size-20 subcat-icon"></span>
+                    <span className="text sm"> Target Reprojection Error </span>
+                </div>
+                <ValueSelector
+                    value={config.target_reprojection_error}
+                    min={0.001}
+                    max={1.0}
+                    step={0.001}
+                    onChange={(target_reprojection_error) =>
+                        dispatch(
+                            triangulationConfigUpdated({target_reprojection_error})
+                        )
+                    }
+                />
+            </div>
+        </div>
     );
-
-}
+};
 
 export default TriangulationSettings;

--- a/freemocap-ui/src/components/pipeline-progress/realtime/realtimepipeline-mediapipedetector-settings.tsx
+++ b/freemocap-ui/src/components/pipeline-progress/realtime/realtimepipeline-mediapipedetector-settings.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import SubactionHeader from '@/components/ui-components/SubactionHeader';
 import IconButton from '@/components/ui-components/IconButton';
 import ValueSelector from '@/components/ui-components/ValueSelector';
+import SegmentedControl from '@/components/ui-components/SegmentedControl';
 import { useRealtimePipelineSync } from '@/hooks/useRealtimePipelineSync';
 import { DetectorType, MediapipeModelComplexity, RTMPOSE_MODELS } from '@/store/slices/mocap';
 import { CameraNodeConfig } from '@/store/slices/realtime/realtime-types';
@@ -74,15 +75,16 @@ const RTPSkeletonSetup: React.FC<RTPSkeletonSetupProps> = ({ open, onClose }) =>
                 <div className="flex p-1 flex-row gap-1 items-center justify-content-space-between">
                     <span className="text-sm">Detector</span>
                     <div className="flex flex-row gap-1">
-                        {(["rtmpose", "mediapipe"] as DetectorType[]).map((type) => (
-                            <button
-                                key={type}
-                                className={`button sm br-1 ${detectorType === type ? "primary accent" : "quaternary"}`}
-                                onClick={() => handleCameraNodeUpdate({ detector_type: type })}
-                            >
-                                {type === "rtmpose" ? "RTMPose" : "MediaPipe"}
-                            </button>
-                        ))}
+                        <SegmentedControl
+                            size="sm"
+                            className="segmented-control-sm bg-darkgray"
+                            value={detectorType ?? "rtmpose"}
+                            options={[
+                                { label: "RTMPose", value: "rtmpose" },
+                                { label: "MediaPipe", value: "mediapipe" },
+                            ]}
+                            onChange={(value) => handleCameraNodeUpdate({ detector_type: value as DetectorType })}
+                        />
                     </div>
                 </div>
 
@@ -97,15 +99,13 @@ const RTPSkeletonSetup: React.FC<RTPSkeletonSetupProps> = ({ open, onClose }) =>
                         <div className="flex p-1 flex-row gap-1 items-center justify-content-space-between">
                             <span className="text-sm">Model</span>
                             <div className="flex flex-row gap-1">
-                                {RTMPOSE_MODELS.map(({ label, value }) => (
-                                    <button
-                                        key={value}
-                                        className={`button sm br-1 ${(cameraNodeConfig.rtmpose_model_name ?? "rtmw-x-l_256x192") === value ? "primary accent" : "quaternary"}`}
-                                        onClick={() => handleCameraNodeUpdate({ rtmpose_model_name: value })}
-                                    >
-                                        {label}
-                                    </button>
-                                ))}
+                                <SegmentedControl
+                                    size="sm"
+                                    className="segmented-control-sm bg-darkgray"
+                                    value={cameraNodeConfig.rtmpose_model_name ?? "rtmw-x-l_256x192"}
+                                    options={RTMPOSE_MODELS}
+                                    onChange={(value) => handleCameraNodeUpdate({ rtmpose_model_name: value as any })}
+                                />
                             </div>
                         </div>
 
@@ -132,15 +132,13 @@ const RTPSkeletonSetup: React.FC<RTPSkeletonSetupProps> = ({ open, onClose }) =>
                         <div className="flex p-1 flex-row gap-1 items-center justify-content-space-between">
                             <span className="text-sm">Model size</span>
                             <div className="flex flex-row gap-1">
-                                {MEDIAPIPE_COMPLEXITIES.map(({ label, value }) => (
-                                    <button
-                                        key={value}
-                                        className={`button sm br-1 ${(cameraNodeConfig.mediapipe_model_complexity ?? "lite") === value ? "primary accent" : "quaternary"}`}
-                                        onClick={() => handleCameraNodeUpdate({ mediapipe_model_complexity: value })}
-                                    >
-                                        {label}
-                                    </button>
-                                ))}
+                                <SegmentedControl
+                                    size="sm"
+                                    className="segmented-control-sm bg-darkgray"
+                                    value={cameraNodeConfig.mediapipe_model_complexity ?? "lite"}
+                                    options={MEDIAPIPE_COMPLEXITIES}
+                                    onChange={(value) => handleCameraNodeUpdate({ mediapipe_model_complexity: value as MediapipeModelComplexity })}
+                                />
                             </div>
                         </div>
 

--- a/freemocap-ui/src/components/ui-components/ValueSelector.tsx
+++ b/freemocap-ui/src/components/ui-components/ValueSelector.tsx
@@ -1,10 +1,20 @@
-import React, {useRef} from "react";
+import React, {useEffect, useRef, useState} from "react";
 import IconButton from "@/components/ui-components/IconButton";
 
-/** Rounds to the precision of `step` and clamps to [min, max], avoiding float drift like 0.005 - 0.0005 = 0.0045000000000000005. */
-function roundToStep(value: number, step: number, min: number, max: number): number {
+/**
+ * Rounds to the precision of `step` and clamps to [min, max],
+ * avoiding float drift like:
+ * 0.005 - 0.0005 = 0.0045000000000000005
+ */
+function roundToStep(
+    value: number,
+    step: number,
+    min: number,
+    max: number
+): number {
     const decimals = (step.toString().split(".")[1] || "").length;
     const rounded = Number(value.toFixed(decimals));
+
     return Math.max(min, Math.min(max, rounded));
 }
 
@@ -18,11 +28,88 @@ interface InputWithUnitProps {
     disabled?: boolean;
 }
 
-const InputWithUnit: React.FC<InputWithUnitProps> = ({value, onChange, unit = "", min = 1, max = 999, step = 1, disabled = false}) => {
+const InputWithUnit: React.FC<InputWithUnitProps> = ({
+    value,
+    onChange,
+    unit = "",
+    min = 1,
+    max = 999,
+    step = 1,
+    disabled = false,
+}) => {
     const inputRef = useRef<HTMLInputElement>(null);
 
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "Enter") {
+    /*
+     * Keep the user's current text separate from the numeric Redux value.
+     *
+     * This allows temporary editing states such as:
+     * "", "0", "0.", and "0.01"
+     */
+    const [inputText, setInputText] = useState(String(value));
+    const [isEditing, setIsEditing] = useState(false);
+
+    /*
+     * Synchronize with external value changes, such as the plus/minus buttons,
+     * as long as the user is not currently typing in the field.
+     */
+    useEffect(() => {
+        if (!isEditing) {
+            setInputText(String(value));
+        }
+    }, [value, isEditing]);
+
+    const commitValue = () => {
+        const trimmedInput = inputText.trim();
+        const parsedValue = Number(trimmedInput);
+
+        /*
+         * An empty or invalid value should restore the last valid external
+         * value instead of being converted immediately to `min`.
+         */
+        if (
+            trimmedInput === "" ||
+            !Number.isFinite(parsedValue)
+        ) {
+            setInputText(String(value));
+            setIsEditing(false);
+            return;
+        }
+
+        const nextValue = roundToStep(
+            parsedValue,
+            step,
+            min,
+            max
+        );
+
+        onChange(nextValue);
+        setInputText(String(nextValue));
+        setIsEditing(false);
+    };
+
+    const handleFocus = (
+        event: React.FocusEvent<HTMLInputElement>
+    ) => {
+        setIsEditing(true);
+
+        /*
+         * Select the current value when entering the field so that typing
+         * immediately replaces it.
+         */
+        event.currentTarget.select();
+    };
+
+    const handleKeyDown = (
+        event: React.KeyboardEvent<HTMLInputElement>
+    ) => {
+        if (event.key === "Enter") {
+            inputRef.current?.blur();
+            return;
+        }
+
+        if (event.key === "Escape") {
+            setInputText(String(value));
+            setIsEditing(false);
             inputRef.current?.blur();
         }
     };
@@ -32,18 +119,25 @@ const InputWithUnit: React.FC<InputWithUnitProps> = ({value, onChange, unit = ""
             <input
                 ref={inputRef}
                 type="number"
-                value={value}
+                value={inputText}
                 min={min}
                 max={max}
                 step={step}
                 disabled={disabled}
-                onChange={e => onChange(Math.max(min, Math.min(max, Number(e.target.value) || min)))}
-                onFocus={e => e.target.select()}
-                onClick={e => e.currentTarget.select()}
+                onChange={(event) =>
+                    setInputText(event.target.value)
+                }
+                onFocus={handleFocus}
+                onBlur={commitValue}
                 onKeyDown={handleKeyDown}
                 className="input-field text md w-full text-center"
             />
-            {unit && <span className="unit-label text md">{unit}</span>}
+
+            {unit && (
+                <span className="unit-label text md">
+                    {unit}
+                </span>
+            )}
         </div>
     );
 };
@@ -58,18 +152,49 @@ interface ValueSelectorProps {
     disabled?: boolean;
 }
 
-const ValueSelector: React.FC<ValueSelectorProps> = ({value, unit = "", min = 1, max = 999, step = 1, onChange, disabled = false}) => {
+const ValueSelector: React.FC<ValueSelectorProps> = ({
+    value,
+    unit = "",
+    min = 1,
+    max = 999,
+    step = 1,
+    onChange,
+    disabled = false,
+}) => {
     const currentValue = value ?? min;
 
     return (
-        <div className={`value-selector-container flex flex-row items-center gap-2 bg-middark br-1 ${disabled ? "disabled" : ""}`}>
+        <div
+            className={
+                `value-selector-container flex flex-row items-center ` +
+                `gap-2 bg-middark br-1 ${disabled ? "disabled" : ""}`
+            }
+        >
             <IconButton
                 icon="minus-icon"
-                onClick={() => currentValue > min && onChange?.(roundToStep(currentValue - step, step, min, max))}
+                onClick={() => {
+                    if (currentValue > min) {
+                        onChange?.(
+                            roundToStep(
+                                currentValue - step,
+                                step,
+                                min,
+                                max
+                            )
+                        );
+                    }
+                }}
                 disabled={disabled || currentValue <= min}
-                className={`icon-size-25 ${disabled || currentValue <= min ? "deactivated" : ""}`}
+                className={
+                    `icon-size-25 ${
+                        disabled || currentValue <= min
+                            ? "deactivated"
+                            : ""
+                    }`
+                }
                 iconSize="icon-size-20"
             />
+
             <InputWithUnit
                 value={currentValue}
                 onChange={onChange ?? (() => {})}
@@ -79,11 +204,29 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({value, unit = "", min = 1,
                 step={step}
                 disabled={disabled}
             />
+
             <IconButton
                 icon="plus-icon"
-                onClick={() => currentValue < max && onChange?.(roundToStep(currentValue + step, step, min, max))}
+                onClick={() => {
+                    if (currentValue < max) {
+                        onChange?.(
+                            roundToStep(
+                                currentValue + step,
+                                step,
+                                min,
+                                max
+                            )
+                        );
+                    }
+                }}
                 disabled={disabled || currentValue >= max}
-                className={`icon-size-25 ${disabled || currentValue >= max ? "deactivated" : ""}`}
+                className={
+                    `icon-size-25 ${
+                        disabled || currentValue >= max
+                            ? "deactivated"
+                            : ""
+                    }`
+                }
                 iconSize="icon-size-20"
             />
         </div>

--- a/freemocap-ui/src/store/slices/mocap/mocap-slice.ts
+++ b/freemocap-ui/src/store/slices/mocap/mocap-slice.ts
@@ -45,6 +45,13 @@ export interface EstimatorConfig {
     iqr_confidence_sensitivity: number;
 }
 
+export interface TriangulationConfig {
+    use_outlier_rejection: boolean;
+    minimum_cameras_for_triangulation: number;
+    maximum_cameras_to_drop: number;
+    target_reprojection_error: number;
+}
+
 export interface PosthocFilterConfig {
     method: "butter_low_pass";
     cutoff: number;
@@ -93,6 +100,7 @@ export const RTMPOSE_MODELS: { label: string; value: RTMPoseModelName }[] = [
 export interface MocapConfig {
     detector: MediapipeDetectorConfig;
     skeleton_filter: RealtimeFilterConfig;
+    triangulation: TriangulationConfig;
     posthoc_filter: PosthocFilterConfig;
     detectorType: DetectorType;
     rtmPoseModelName: RTMPoseModelName;
@@ -173,6 +181,14 @@ export function detectPreset(
  *   NOTE: beta = 0.3 (meter-space convention) is ~1000× too high.
  */
 
+export const DEFAULT_TRIANGULATION_CONFIG: TriangulationConfig = {
+    use_outlier_rejection: true,
+    minimum_cameras_for_triangulation: 2,
+    maximum_cameras_to_drop: 1,
+    target_reprojection_error: 0.01,
+};
+
+
 export const DEFAULT_REALTIME_FILTER_CONFIG: RealtimeFilterConfig = {
     min_cutoff: 1.0,
     beta: 0.007,
@@ -225,6 +241,7 @@ export interface MocapState {
 
 const DEFAULT_MOCAP_CONFIG: MocapConfig = {
     detector: {...MEDIAPIPE_REALTIME_PRESET},
+    triangulation: {...DEFAULT_TRIANGULATION_CONFIG},
     skeleton_filter: {...DEFAULT_REALTIME_FILTER_CONFIG},
     posthoc_filter: {...DEFAULT_POSTHOC_FILTER_CONFIG},
 
@@ -250,6 +267,11 @@ const initialMocapConfig: MocapConfig = {
     detector: {
         ...DEFAULT_MOCAP_CONFIG.detector,
         ...(_persistedMocapConfig?.detector ?? {}),
+    },
+
+    triangulation: {
+        ...DEFAULT_MOCAP_CONFIG.triangulation,
+        ...(_persistedMocapConfig?.triangulation ?? {}),
     },
 
     skeleton_filter: {
@@ -337,6 +359,10 @@ export const mocapSlice = createSlice({
         /** Partially update individual skeleton filter fields. */
         skeletonFilterConfigUpdated: (state, action: PayloadAction<Partial<RealtimeFilterConfig>>) => {
             state.config.skeleton_filter = { ...state.config.skeleton_filter, ...action.payload };
+        },
+
+        triangulationConfigUpdated: (state, action: PayloadAction<Partial<TriangulationConfig>>) => {
+            state.config.triangulation = { ...state.config.triangulation, ...action.payload };
         },
 
         posthocFilterConfigUpdated: (state, action: PayloadAction<Partial<PosthocFilterConfig>>) => {
@@ -429,6 +455,7 @@ export const mocapSlice = createSlice({
 export const selectMocap = (state: RootState) => state.mocap;
 export const selectMocapConfig = (state: RootState) => state.mocap.config;
 export const selectMocapDetectorConfig = (state: RootState) => state.mocap.config.detector;
+export const selectMocapTriangulationConfig = (state: RootState) => state.mocap.config.triangulation;
 export const selectSkeletonFilterConfig = (state: RootState) => state.mocap.config.skeleton_filter;
 export const selectPosthocFilterConfig = (state: RootState) => state.mocap.config.posthoc_filter;
 export const selectMocapDetectorType = (state: RootState) => state.mocap.config.detectorType;
@@ -502,6 +529,7 @@ export const {
     mocapDetectorConfigUpdated,
     skeletonFilterConfigReplaced,
     skeletonFilterConfigUpdated,
+    triangulationConfigUpdated,
     posthocFilterConfigUpdated,
     mocapProgressUpdated,
     mocapErrorCleared,

--- a/freemocap-ui/src/store/slices/mocap/mocap-slice.ts
+++ b/freemocap-ui/src/store/slices/mocap/mocap-slice.ts
@@ -185,7 +185,7 @@ export const DEFAULT_TRIANGULATION_CONFIG: TriangulationConfig = {
     use_outlier_rejection: true,
     minimum_cameras_for_triangulation: 2,
     maximum_cameras_to_drop: 1,
-    target_reprojection_error: 0.01,
+    target_reprojection_error: 0.02,
 };
 
 

--- a/freemocap-ui/src/store/slices/mocap/mocap-thunks.ts
+++ b/freemocap-ui/src/store/slices/mocap/mocap-thunks.ts
@@ -23,6 +23,7 @@ function buildPosthocConfig(state: RootState) {
         mediapipeNumHands: config.mediapipeNumHands,
         mediapipeNumFaces: config.mediapipeNumFaces,
         calibrationTomlPath,
+        triangulationConfig: config.triangulation,
         filterConfig: config.posthoc_filter,
         exportToBlender: blender.exportToBlenderEnabled,
         blenderExePath: blender.blenderExePath ?? blender.detectedBlenderExePath,

--- a/freemocap/core/tasks/mocap/mocap_task_config.py
+++ b/freemocap/core/tasks/mocap/mocap_task_config.py
@@ -23,6 +23,7 @@ from skellytracker.core.temporal_processing.temporal_processing_config import (
 )
 
 from skellyforge.post_processing.filters.filter_config import FilterConfig
+from freemocap.core.tasks.triangulation.helpers.triangulation_config import TriangulationConfig
 
 
 
@@ -99,6 +100,12 @@ class PosthocMocapPipelineConfig(BaseModel):
         default=None,
         alias="calibrationTomlPath",
         description="Path to calibration TOML. If None, the most-recent successful calibration is used.",
+    )
+
+    triangulation_config: TriangulationConfig = Field(
+        default=TriangulationConfig(),
+        alias="triangulationConfig",
+        description="Configuration for the triangulation step of the mocap pipeline.",
     )
 
     filter_config:FilterConfig = Field(

--- a/freemocap/core/tasks/mocap/mocap_task_config.py
+++ b/freemocap/core/tasks/mocap/mocap_task_config.py
@@ -103,7 +103,7 @@ class PosthocMocapPipelineConfig(BaseModel):
     )
 
     triangulation_config: TriangulationConfig = Field(
-        default=TriangulationConfig(),
+        default_factory=TriangulationConfig,
         alias="triangulationConfig",
         description="Configuration for the triangulation step of the mocap pipeline.",
     )

--- a/freemocap/core/tasks/mocap/posthoc_mocap_task.py
+++ b/freemocap/core/tasks/mocap/posthoc_mocap_task.py
@@ -108,7 +108,8 @@ def run_posthoc_mocap_aggregator_task(
         observation_recorders=observation_recorders,
         path_to_calibration_toml=calibration_toml_path,
         path_to_output_data_folder=output_folder,
-        filter_config=task_config.filter_config
+        filter_config=task_config.filter_config,
+        triangulation_config=task_config.triangulation_config
     )
 
     # ---- Save tracker schema alongside outputs ----

--- a/freemocap/core/tasks/triangulation/triangulator.py
+++ b/freemocap/core/tasks/triangulation/triangulator.py
@@ -241,6 +241,7 @@ class Triangulator(BaseModel):
             )  # (n_batch, 3)
 
             if config.use_outlier_rejection:
+                logger.info("Using outlier rejection with target reprojection error %.4f", config.target_reprojection_error)
                 # Batch-project to check normalized reprojection error
                 n_batch = batch_idx.size
                 hom = np.concatenate(


### PR DESCRIPTION
Exposing outlier triangulation settings in the GUI and separating the triangulation settings from the postprocessing settings:

<img width="731" height="492" alt="image" src="https://github.com/user-attachments/assets/3fa08fba-2a3f-4132-9638-b7c0238aa42a" />