### PR TITLE
designs for aaron::expose outliner rejection options - branch

### DIFF
--- a/freemocap-ui/src/components/mocap-setup/mocap-triangulation-settings.tsx
+++ b/freemocap-ui/src/components/mocap-setup/mocap-triangulation-settings.tsx
@@ -1,86 +1,91 @@
 import React from "react";
-import { useAppDispatch, useAppSelector } from "@/store/hooks";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
 import {
     triangulationConfigUpdated,
     selectMocapTriangulationConfig
-} from "@/store/slices/mocap";
+} from "../../store/slices/mocap";
 
-import ValueSelector from "@/components/ui-components/ValueSelector"
+import ValueSelector from "../ui-components/ValueSelector";
+import ToggleComponent from "../ui-components/ToggleComponent";
 import SubactionHeader from "../ui-components/SubactionHeader";
-import Checkbox from "../ui-components/Checkbox";
 
-const TriangulationSettings:React.FC = () => {
+const TriangulationSettings: React.FC = () => {
     const dispatch = useAppDispatch();
-    const config = useAppSelector(selectMocapTriangulationConfig)
+    const config = useAppSelector(selectMocapTriangulationConfig);
 
     return (
-        <div className = "flex flex-col gap-1">
-            <SubactionHeader text = "Triangulation Settings" />
+        <div className="flex flex-col gap-1">
+            <SubactionHeader text="Triangulation Settings" />
 
-        
-        <Checkbox
-        label="Use outlier rejection"
-        checked={config.use_outlier_rejection}
-        onChange={(event) =>
-            dispatch(
-            triangulationConfigUpdated({
-                use_outlier_rejection: event.target.checked,
-            })
-            )}
-    
-        />
-
-        <div className = "flex flex-row p-1 items-center justify-content-space-between">
-            <span className = "text sm"> Minimum Cameras for Triangulation </span>
-            <ValueSelector
-                value = {config.minimum_cameras_for_triangulation}
-                min = {2}
-                max = {100}
-                onChange = {(minimum_cameras_for_triangulation) =>
+            <ToggleComponent
+                text="Use outlier rejection"
+                isToggled={config.use_outlier_rejection}
+                onToggle={(checked) =>
                     dispatch(
                         triangulationConfigUpdated({
-                            minimum_cameras_for_triangulation: minimum_cameras_for_triangulation,
+                            use_outlier_rejection: checked,
                         })
                     )
                 }
             />
-        </div>
 
-        <div className = "flex flex-row p-1 items-center justify-content-space-between">
-            <span className = "text sm"> Maximum Cameras to Drop </span>
-            <ValueSelector
-                value = {config.maximum_cameras_to_drop}
-                min = {0}
-                max = {100}
-                onChange = {(maximum_cameras_to_drop) =>
-                    dispatch(
-                        triangulationConfigUpdated({
-                            maximum_cameras_to_drop: maximum_cameras_to_drop,
-                        })
-                    )
-                }
-            />
-        </div>
+            <div className={`flex flex-row p-1 items-center justify-content-space-between ${config.use_outlier_rejection ? '' : 'disabled'}`}>
+                <div className="flex items-center gap-1 flex-wrap">
+                    <span className="icon icon-size-20 subcat-icon"></span>
+                    <span className="text sm"> Minimum Cameras for Triangulation </span>
+                </div>
+                <ValueSelector
+                    value={config.minimum_cameras_for_triangulation}
+                    min={2}
+                    max={100}
+                    onChange={(minimum_cameras_for_triangulation) =>
+                        dispatch(
+                            triangulationConfigUpdated({
+                                minimum_cameras_for_triangulation: minimum_cameras_for_triangulation,
+                            })
+                        )
+                    }
+                />
+            </div>
 
-        <div className = "flex flex-row p-1 items-center justify-content-space-between">
-            <span className = "text sm"> Target Reprojection Error </span>
-            <ValueSelector
-                value = {config.target_reprojection_error}
-                min = {0.001}
-                max = {1.0}
-                step = {0.001}
-                onChange = {(target_reprojection_error) =>
-                    dispatch(
-                        triangulationConfigUpdated({target_reprojection_error})
-                    )
-                }
-            />
-        </div>
-    </div>  
+            <div className={`flex flex-row p-1 items-center justify-content-space-between ${config.use_outlier_rejection ? '' : 'disabled'}`}>
+                <div className="flex items-center gap-1 flex-wrap">
+                    <span className="icon icon-size-20 subcat-icon"></span>
+                    <span className="text sm"> Maximum Cameras to Drop </span>
+                </div>
+                <ValueSelector
+                    value={config.maximum_cameras_to_drop}
+                    min={0}
+                    max={100}
+                    onChange={(maximum_cameras_to_drop) =>
+                        dispatch(
+                            triangulationConfigUpdated({
+                                maximum_cameras_to_drop: maximum_cameras_to_drop,
+                            })
+                        )
+                    }
+                />
+            </div>
 
-            
+            <div className={`flex flex-row p-1 items-center justify-content-space-between ${config.use_outlier_rejection ? '' : 'disabled'}`}>
+                <div className="flex items-center gap-1 flex-wrap">
+                    <span className="icon icon-size-20 subcat-icon"></span>
+                    <span className="text sm"> Target Reprojection Error </span>
+                </div>
+                <ValueSelector
+                    value={config.target_reprojection_error}
+                    min={0.001}
+                    max={1.0}
+                    step={0.001}
+                    onChange={(target_reprojection_error) =>
+                        dispatch(
+                            triangulationConfigUpdated({target_reprojection_error})
+                        )
+                    }
+                />
+            </div>
+        </div>
     );
-
-}
+};
 
 export default TriangulationSettings;

--- a/freemocap-ui/src/components/pipeline-progress/realtime/realtimepipeline-mediapipedetector-settings.tsx
+++ b/freemocap-ui/src/components/pipeline-progress/realtime/realtimepipeline-mediapipedetector-settings.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import SubactionHeader from '@/components/ui-components/SubactionHeader';
 import IconButton from '@/components/ui-components/IconButton';
 import ValueSelector from '@/components/ui-components/ValueSelector';
+import SegmentedControl from '@/components/ui-components/SegmentedControl';
 import { useRealtimePipelineSync } from '@/hooks/useRealtimePipelineSync';
 import { DetectorType, MediapipeModelComplexity, RTMPOSE_MODELS } from '@/store/slices/mocap';
 import { CameraNodeConfig } from '@/store/slices/realtime/realtime-types';
@@ -74,15 +75,16 @@ const RTPSkeletonSetup: React.FC<RTPSkeletonSetupProps> = ({ open, onClose }) =>
                 <div className="flex p-1 flex-row gap-1 items-center justify-content-space-between">
                     <span className="text-sm">Detector</span>
                     <div className="flex flex-row gap-1">
-                        {(["rtmpose", "mediapipe"] as DetectorType[]).map((type) => (
-                            <button
-                                key={type}
-                                className={`button sm br-1 ${detectorType === type ? "primary accent" : "quaternary"}`}
-                                onClick={() => handleCameraNodeUpdate({ detector_type: type })}
-                            >
-                                {type === "rtmpose" ? "RTMPose" : "MediaPipe"}
-                            </button>
-                        ))}
+                        <SegmentedControl
+                            size="sm"
+                            className="segmented-control-sm bg-darkgray"
+                            value={detectorType ?? "rtmpose"}
+                            options={[
+                                { label: "RTMPose", value: "rtmpose" },
+                                { label: "MediaPipe", value: "mediapipe" },
+                            ]}
+                            onChange={(value) => handleCameraNodeUpdate({ detector_type: value as DetectorType })}
+                        />
                     </div>
                 </div>
 
@@ -97,15 +99,13 @@ const RTPSkeletonSetup: React.FC<RTPSkeletonSetupProps> = ({ open, onClose }) =>
                         <div className="flex p-1 flex-row gap-1 items-center justify-content-space-between">
                             <span className="text-sm">Model</span>
                             <div className="flex flex-row gap-1">
-                                {RTMPOSE_MODELS.map(({ label, value }) => (
-                                    <button
-                                        key={value}
-                                        className={`button sm br-1 ${(cameraNodeConfig.rtmpose_model_name ?? "rtmw-x-l_256x192") === value ? "primary accent" : "quaternary"}`}
-                                        onClick={() => handleCameraNodeUpdate({ rtmpose_model_name: value })}
-                                    >
-                                        {label}
-                                    </button>
-                                ))}
+                                <SegmentedControl
+                                    size="sm"
+                                    className="segmented-control-sm bg-darkgray"
+                                    value={cameraNodeConfig.rtmpose_model_name ?? "rtmw-x-l_256x192"}
+                                    options={RTMPOSE_MODELS}
+                                    onChange={(value) => handleCameraNodeUpdate({ rtmpose_model_name: value as any })}
+                                />
                             </div>
                         </div>
 
@@ -132,15 +132,13 @@ const RTPSkeletonSetup: React.FC<RTPSkeletonSetupProps> = ({ open, onClose }) =>
                         <div className="flex p-1 flex-row gap-1 items-center justify-content-space-between">
                             <span className="text-sm">Model size</span>
                             <div className="flex flex-row gap-1">
-                                {MEDIAPIPE_COMPLEXITIES.map(({ label, value }) => (
-                                    <button
-                                        key={value}
-                                        className={`button sm br-1 ${(cameraNodeConfig.mediapipe_model_complexity ?? "lite") === value ? "primary accent" : "quaternary"}`}
-                                        onClick={() => handleCameraNodeUpdate({ mediapipe_model_complexity: value })}
-                                    >
-                                        {label}
-                                    </button>
-                                ))}
+                                <SegmentedControl
+                                    size="sm"
+                                    className="segmented-control-sm bg-darkgray"
+                                    value={cameraNodeConfig.mediapipe_model_complexity ?? "lite"}
+                                    options={MEDIAPIPE_COMPLEXITIES}
+                                    onChange={(value) => handleCameraNodeUpdate({ mediapipe_model_complexity: value as MediapipeModelComplexity })}
+                                />
                             </div>
                         </div>
 


### PR DESCRIPTION
- [x] uses conditional toggle for use outliner  rejection - and visually gr…oups the 3 items below it

<img width="779" height="382" alt="image" src="https://github.com/user-attachments/assets/699a784f-e44f-47be-898b-40319282a3ae" />


<img width="737" height="356" alt="image" src="https://github.com/user-attachments/assets/1291be07-2481-42fe-88be-0b8f9f890f4d" />

--

- [x] use segmented controls for realtine mocap settings similar to mocap modal settings

<img width="459" height="546" alt="image" src="https://github.com/user-attachments/assets/ef36f766-d68b-47cf-84a9-e5d530945423" />
