### PR TITLE
Remove calibration toml search for single camera recordings

### DIFF
--- a/freemocap-ui/electron/main/api.ts
+++ b/freemocap-ui/electron/main/api.ts
@@ -22,30 +22,36 @@ autoUpdater.allowDowngrade = false;
 const t = initTRPC.create({
     transformer: superjson, // Handles Date/undefined/etc serialization
 });
-// Helper function to check if a directory contains video files
-function hasVideoFiles(dirPath: string): boolean {
+const VIDEO_EXTENSIONS = ['.mp4', '.avi', '.mov', '.mkv', '.wmv', '.flv', '.webm'];
+
+// Helper function to count video files directly inside a directory (one file per camera)
+function countVideoFiles(dirPath: string): number {
     if (!fs.existsSync(dirPath)) {
-        return false;
+        return 0;
     }
 
     try {
         const entries = fs.readdirSync(dirPath);
-        const videoExtensions = ['.mp4', '.avi', '.mov', '.mkv', '.wmv', '.flv', '.webm'];
 
-        return entries.some(entry => {
+        return entries.filter(entry => {
             const fullPath = path.join(dirPath, entry);
             const stats = fs.statSync(fullPath);
 
             if (stats.isFile()) {
                 const ext = path.extname(entry).toLowerCase();
-                return videoExtensions.includes(ext);
+                return VIDEO_EXTENSIONS.includes(ext);
             }
             return false;
-        });
+        }).length;
     } catch (error) {
-        console.error('Error checking for video files:', error);
-        return false;
+        console.error('Error counting video files:', error);
+        return 0;
     }
+}
+
+// Helper function to check if a directory contains video files
+function hasVideoFiles(dirPath: string): boolean {
+    return countVideoFiles(dirPath) > 0;
 }
 
 // Helper function to find camera calibration TOML file
@@ -362,6 +368,7 @@ export const api = t.router({
                     lastSuccessfulCalibrationTomlPath: null as string | null,
                     hasSynchronizedVideos: false,
                     hasVideos: false,
+                    cameraCount: 0,
                     errorMessage: null as string | null,
                 };
 
@@ -387,12 +394,14 @@ export const api = t.router({
                         fs.statSync(synchronizedVideosPath).isDirectory();
 
                     if (result.hasSynchronizedVideos) {
-                        result.hasVideos = hasVideoFiles(synchronizedVideosPath);
+                        result.cameraCount = countVideoFiles(synchronizedVideosPath);
                     }
 
-                    if (!result.hasVideos) {
-                        result.hasVideos = hasVideoFiles(input.directoryPath);
+                    if (result.cameraCount === 0) {
+                        result.cameraCount = countVideoFiles(input.directoryPath);
                     }
+
+                    result.hasVideos = result.cameraCount > 0;
 
                     const entries = fs.readdirSync(input.directoryPath);
                     result.canRecord = !result.hasVideos;
@@ -401,7 +410,10 @@ export const api = t.router({
 
                     result.canCalibrate = result.hasVideos && result.cameraMocapTomlPath !== null;
 
-                    result.canProcess = result.hasVideos && result.cameraMocapTomlPath !== null;
+                    // Single-camera recordings use a planar-projection fallback and never need
+                    // a calibration TOML; multi-camera recordings still require one for triangulation.
+                    const hasCalibration = result.cameraMocapTomlPath !== null || result.lastSuccessfulCalibrationTomlPath !== null;
+                    result.canProcess = result.hasVideos && (result.cameraCount === 1 || hasCalibration);
 
                     return result;
 

--- a/freemocap-ui/src/components/control-panels/mocap-control-panel/MocapPanel.tsx
+++ b/freemocap-ui/src/components/control-panels/mocap-control-panel/MocapPanel.tsx
@@ -181,6 +181,7 @@ export const MocapPanel: React.FC = () => {
         if (!mocapRecordingPath) return "Select a recording folder to process";
         if (!directoryInfo?.hasVideos) return "No videos found in the selected recording folder";
         const hasAnyCalibration =
+            directoryInfo?.cameraCount === 1 ||
             !!calibrationTomlPath ||
             !!directoryInfo?.cameraMocapTomlPath ||
             !!directoryInfo?.lastSuccessfulCalibrationTomlPath;

--- a/freemocap-ui/src/components/control-panels/mocap-control-panel/MocapTaskTreeItem.tsx
+++ b/freemocap-ui/src/components/control-panels/mocap-control-panel/MocapTaskTreeItem.tsx
@@ -190,6 +190,7 @@ export const MocapTaskTreeItem: React.FC = () => {
         if (!mocapRecordingPath) return "Select a recording folder to process";
         if (!directoryInfo?.hasVideos) return "No videos found in the selected recording folder";
         const hasAnyCalibration =
+            directoryInfo?.cameraCount === 1 ||
             !!calibrationTomlPath ||
             !!directoryInfo?.cameraMocapTomlPath ||
             !!directoryInfo?.lastSuccessfulCalibrationTomlPath;

--- a/freemocap-ui/src/components/mocap-setup/mocap-setup-modal.tsx
+++ b/freemocap-ui/src/components/mocap-setup/mocap-setup-modal.tsx
@@ -38,6 +38,7 @@ const MocapSetupModal: React.FC<MocapSetupModalProps> = ({
     if (!mocapRecordingPath) return "Select a recording folder to process";
     if (!directoryInfo?.hasVideos) return "No videos found in the selected recording folder";
     const hasAnyCalibration =
+      directoryInfo?.cameraCount === 1 ||
       !!calibrationTomlPath ||
       !!directoryInfo?.cameraMocapTomlPath ||
       !!directoryInfo?.lastSuccessfulCalibrationTomlPath;

--- a/freemocap-ui/src/hooks/useMocap.ts
+++ b/freemocap-ui/src/hooks/useMocap.ts
@@ -57,6 +57,7 @@ function mocapDirectoryInfoEqual(a: MocapDirectoryInfo | null, b: MocapDirectory
         a.canCalibrate === b.canCalibrate &&
         a.hasSynchronizedVideos === b.hasSynchronizedVideos &&
         a.hasVideos === b.hasVideos &&
+        a.cameraCount === b.cameraCount &&
         a.cameraMocapTomlPath === b.cameraMocapTomlPath &&
         a.lastSuccessfulCalibrationTomlPath === b.lastSuccessfulCalibrationTomlPath &&
         a.errorMessage === b.errorMessage

--- a/freemocap-ui/src/store/slices/mocap/mocap-slice.ts
+++ b/freemocap-ui/src/store/slices/mocap/mocap-slice.ts
@@ -222,6 +222,7 @@ export interface MocapDirectoryInfo {
     lastSuccessfulCalibrationTomlPath: string | null;
     hasSynchronizedVideos: boolean;
     hasVideos: boolean;
+    cameraCount: number;
     errorMessage: string | null;
 }
 
@@ -505,11 +506,14 @@ export const selectCanProcessMocapRecording = createSelector(
     ],
     (mocapPath, isLoading, isRecording, directoryInfo, manualCalibrationTomlPath) => {
         const hasVideos = directoryInfo?.hasVideos ?? false;
+        // Single-camera recordings use a planar-projection fallback and never need
+        // a calibration TOML; multi-camera recordings still require one for triangulation.
+        const isSingleCamera = directoryInfo?.cameraCount === 1;
         const hasAnyCalibrationToml =
             !!manualCalibrationTomlPath ||
             !!directoryInfo?.cameraMocapTomlPath ||
             !!directoryInfo?.lastSuccessfulCalibrationTomlPath;
-        return !!mocapPath && !isLoading && !isRecording && hasVideos && hasAnyCalibrationToml;
+        return !!mocapPath && !isLoading && !isRecording && hasVideos && (isSingleCamera || hasAnyCalibrationToml);
     }
 );
 

--- a/freemocap/core/tasks/mocap/mocap_helpers/skeleton_from_mediapipe_observations.py
+++ b/freemocap/core/tasks/mocap/mocap_helpers/skeleton_from_mediapipe_observations.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def skeleton_from_mediapipe_observation_recorders(
     detector:str,
     observation_recorders: dict[CameraIdString, ObservationBuffer],
-    path_to_calibration_toml: Path | str,
+    path_to_calibration_toml: Path | str | None,
     path_to_output_data_folder: Path | str,
     triangulation_config: TriangulationConfig | None = None,
     interp_config: InterpolationConfig | None = None,

--- a/freemocap/core/tasks/mocap/posthoc_mocap_task.py
+++ b/freemocap/core/tasks/mocap/posthoc_mocap_task.py
@@ -71,8 +71,12 @@ def run_posthoc_mocap_aggregator_task(
         for cam_id, obs in frame_obs.items():
             observation_recorders[cam_id].add_observation(obs)
 
-    # ---- Get calibration path: explicit path wins; else fall back to most-recent ----
-    if task_config.calibration_toml_path:
+    # ---- Get calibration path: not needed for single-camera (planar projection fallback) ----
+    recording_folder = Path(recording_info.full_recording_path)
+    calibration_toml_path: Path | None = None
+    if len(camera_ids) == 1:
+        logger.info("Single camera recording; skipping calibration requirement (using planar projection fallback).")
+    elif task_config.calibration_toml_path:
         calibration_toml_path = Path(task_config.calibration_toml_path)
         if not calibration_toml_path.exists():
             raise RuntimeError(
@@ -89,13 +93,13 @@ def run_posthoc_mocap_aggregator_task(
         logger.info(f"No calibration path specified; using most-recent calibration: {calibration_toml_path}")
 
     # ---- Copy calibration file into recording folder ----
-    recording_folder = Path(recording_info.full_recording_path)
-    recording_calibration_copy = recording_folder / calibration_toml_path.name
-    if calibration_toml_path.resolve() != recording_calibration_copy.resolve():
-        shutil.copy2(calibration_toml_path, recording_calibration_copy)
-        logger.info(f"Copied calibration file to recording folder: {recording_calibration_copy}")
-    else:
-        logger.info(f"Calibration file already in recording folder, skipping copy: {recording_calibration_copy}")
+    if calibration_toml_path is not None:
+        recording_calibration_copy = recording_folder / calibration_toml_path.name
+        if calibration_toml_path.resolve() != recording_calibration_copy.resolve():
+            shutil.copy2(calibration_toml_path, recording_calibration_copy)
+            logger.info(f"Copied calibration file to recording folder: {recording_calibration_copy}")
+        else:
+            logger.info(f"Calibration file already in recording folder, skipping copy: {recording_calibration_copy}")
 
     # ---- Run skeleton triangulation ----
     _reporter.report(stage=MocapStage.TRIANGULATING, detail="Triangulating skeleton")


### PR DESCRIPTION
Fixes #841 - Removes some checks for calibration toml when there is only one camera selected. Also handles missing tomls better in the backend.