### PR TITLE
Fix file browsing on mac

### DIFF
--- a/freemocap-ui/electron/main/api.ts
+++ b/freemocap-ui/electron/main/api.ts
@@ -167,9 +167,18 @@ export const api = t.router({
     // File System Operations
     fileSystem: t.router({
         selectDirectory: t.procedure
-            .mutation(async () => {
+            .input(z.object({ defaultPath: z.string().optional() }).optional())
+            .mutation(async ({ input }) => {
+                // Without an explicit defaultPath, macOS's NSOpenPanel falls back to
+                // whatever directory it last remembered for this app's bundle identity
+                // (e.g. Documents for a freshly-signed packaged build) instead of the
+                // directory the user is currently browsing.
+                const defaultPath = input?.defaultPath && fs.existsSync(input.defaultPath)
+                    ? input.defaultPath
+                    : undefined;
                 const result = await dialog.showOpenDialog({
                     properties: ['openDirectory'],
+                    ...(defaultPath ? { defaultPath } : {}),
                 });
                 return result.canceled ? null : result.filePaths[0];
             }),
@@ -177,7 +186,10 @@ export const api = t.router({
         openFolder: t.procedure
             .input(z.object({ path: z.string() }))
             .mutation(async ({ input }) => {
-                await shell.openPath(input.path);
+                const errorMessage = await shell.openPath(input.path);
+                if (errorMessage) {
+                    throw new Error(errorMessage);
+                }
                 return true;
             }),
 

--- a/freemocap-ui/src/components/control-panels/mocap-control-panel/MocapPanel.tsx
+++ b/freemocap-ui/src/components/control-panels/mocap-control-panel/MocapPanel.tsx
@@ -89,7 +89,9 @@ export const MocapPanel: React.FC = () => {
     const handleSelectDirectory = async (): Promise<void> => {
         if (!isElectron || !api) return;
         try {
-            const result: string | null = await api.fileSystem.selectDirectory.mutate();
+            const result: string | null = await api.fileSystem.selectDirectory.mutate({
+                defaultPath: mocapRecordingPath || undefined,
+            });
             if (result) {
                 await setManualRecordingPath(result);
             }

--- a/freemocap-ui/src/components/control-panels/mocap-control-panel/MocapTaskTreeItem.tsx
+++ b/freemocap-ui/src/components/control-panels/mocap-control-panel/MocapTaskTreeItem.tsx
@@ -57,7 +57,9 @@ export const MocapTaskTreeItem: React.FC = () => {
             return;
         }
         try {
-            const result: string | null = await api.fileSystem.selectDirectory.mutate();
+            const result: string | null = await api.fileSystem.selectDirectory.mutate({
+                defaultPath: mocapRecordingPath || undefined,
+            });
             if (result) {
                 await setManualRecordingPath(result);
             }

--- a/freemocap-ui/src/components/control-panels/recording-info-panel/RecordingPathTreeItem.tsx
+++ b/freemocap-ui/src/components/control-panels/recording-info-panel/RecordingPathTreeItem.tsx
@@ -62,7 +62,9 @@ export const RecordingPathTreeItem: React.FC<RecordingPathTreeItemProps> = ({
     const handleSelectDirectory = async (): Promise<void> => {
         if (!isElectron || !api) return;
         try {
-            const result: string | null = await api.fileSystem.selectDirectory.mutate();
+            const result: string | null = await api.fileSystem.selectDirectory.mutate({
+                defaultPath: recordingDirectory || undefined,
+            });
             if (result) dispatch(recordingDirectoryChanged(result));
         } catch (error) {
             console.error('Failed to select directory:', error);

--- a/freemocap-ui/src/components/mocap-setup/mocap-processing-directory.tsx
+++ b/freemocap-ui/src/components/mocap-setup/mocap-processing-directory.tsx
@@ -28,7 +28,9 @@ const ProcessDirectoryModule: React.FC<ProcessDirectoryModuleProps> = ({
   const handleSelectDirectory = async (): Promise<void> => {
     if (!isElectron || !api) return;
     try {
-      const result: string | null = await api.fileSystem.selectDirectory.mutate();
+      const result: string | null = await api.fileSystem.selectDirectory.mutate({
+        defaultPath: mocapRecordingPath || undefined,
+      });
       if (result) await setManualRecordingPath(result);
     } catch (error) {
       console.error("Failed to select directory:", error);

--- a/freemocap-ui/src/components/playback/RecordingBrowser.tsx
+++ b/freemocap-ui/src/components/playback/RecordingBrowser.tsx
@@ -333,12 +333,14 @@ export const RecordingBrowser: React.FC<RecordingBrowserProps> = ({
 
   const handleBrowseDirectory = useCallback(async () => {
     if (!isElectron || !api) return;
-    const result: string | null = await api.fileSystem.selectDirectory.mutate();
+    const result: string | null = await api.fileSystem.selectDirectory.mutate({
+      defaultPath: manualPath || undefined,
+    });
     if (!result) return;
     const trimmed = result.trim().replace(/[\\/]+$/, "");
     setManualPath(trimmed);
     loadRecording(trimmed);
-  }, [api, isElectron, loadRecording]);
+  }, [api, isElectron, loadRecording, manualPath]);
 
   const toggleSortDir = () => {
     setSortDir((d) => (d === "desc" ? "asc" : "desc"));

--- a/freemocap-ui/src/components/ui-components/SettingsModal.tsx
+++ b/freemocap-ui/src/components/ui-components/SettingsModal.tsx
@@ -78,7 +78,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({open, onClose}) => 
 
     const handleChangeFolder = useCallback(async () => {
         if (!api || busy || isRecording) return;
-        const selected = await api.fileSystem.selectDirectory.mutate();
+        const selected = await api.fileSystem.selectDirectory.mutate({
+            defaultPath: baseFolder || undefined,
+        });
         if (!selected) return; // user canceled the picker
         setBusy(true);
         setStatus('Applying data folder…');


### PR DESCRIPTION
Adds a default path to the file directory calls to fix file paths on the built mac version. Fixes #828 