### PR TITLE
Send websocket message when pipeline is stopped by user

### DIFF
--- a/freemocap-ui/src/components/mocap-setup/mocap-setup-modal.tsx
+++ b/freemocap-ui/src/components/mocap-setup/mocap-setup-modal.tsx
@@ -29,7 +29,14 @@ const MocapSetupModal: React.FC<MocapSetupModalProps> = ({
     directoryInfo,
     calibrationTomlPath,
     dispatchProcessMocapRecording,
+    validateDirectory,
   } = useMocap();
+
+  useEffect(() => {
+    if (mocapRecordingPath) {
+      validateDirectory(mocapRecordingPath);
+    }
+  }, [mocapRecordingPath, validateDirectory]);
 
   const processBlockedReason = useMemo((): string | null => {
     if (canProcessMocapRecording) return null;

--- a/freemocap/core/pipeline/posthoc/posthoc_pipeline_manager.py
+++ b/freemocap/core/pipeline/posthoc/posthoc_pipeline_manager.py
@@ -26,7 +26,7 @@ from freemocap.core.tasks.calibration.posthoc_calibration_task import run_postho
 from freemocap.core.tasks.mocap.mocap_task_config import PosthocMocapPipelineConfig
 from freemocap.core.tasks.mocap.posthoc_mocap_task import run_posthoc_mocap_aggregator_task
 from freemocap.core.types.type_overloads import PipelineIdString
-from freemocap.core.pipeline.posthoc.progress_messages import PipelineProgressMessage
+from freemocap.core.pipeline.posthoc.progress_messages import AggregatorNodeProgressMessage, PipelineProgressMessage
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +45,10 @@ class PosthocPipelineManager(PipelineManagerABC):
     worker_registry: WorkerRegistry
     lock: multiprocessing.synchronize.Lock = field(default_factory=multiprocessing.Lock)
     pipelines: dict[PipelineIdString, PosthocPipeline] = field(default_factory=dict)
+    # Synthetic terminal messages for pipelines stopped manually (via stop_pipeline/
+    # stop_all_pipelines), which never emit their own terminal COMPLETE/FAILED message
+    # since they're killed rather than left to finish. Drained by get_progress_updates().
+    pending_stop_messages: list[PipelineProgressMessage] = field(default_factory=list)
 
     # ------------------------------------------------------------------
     # Lazy cleanup
@@ -173,10 +177,23 @@ class PosthocPipelineManager(PipelineManagerABC):
     # Lifecycle
     # ------------------------------------------------------------------
 
+    def _stopped_by_user_message(self, pipeline: PosthocPipeline) -> AggregatorNodeProgressMessage:
+        return AggregatorNodeProgressMessage(
+            pipeline_id=pipeline.id,
+            pipeline_type=str(pipeline.pipeline_type),
+            phase="failed",
+            progress_fraction=0.0,
+            detail="Stopped by user",
+            recording_name=pipeline.recording_info.recording_name,
+            recording_path=str(pipeline.recording_info.full_recording_path),
+        )
+
     def stop_pipeline(self, pipeline_id: PipelineIdString) -> bool:
         """Shutdown a single pipeline by ID. Returns True if found, False if not."""
         with self.lock:
             pipeline = self.pipelines.pop(pipeline_id, None)
+            if pipeline is not None:
+                self.pending_stop_messages.append(self._stopped_by_user_message(pipeline))
         if pipeline is None:
             logger.warning(f"stop_pipeline: pipeline [{pipeline_id}] not found")
             return False
@@ -189,6 +206,9 @@ class PosthocPipelineManager(PipelineManagerABC):
         with self.lock:
             pipelines = list(self.pipelines.values())
             self.pipelines.clear()
+            self.pending_stop_messages.extend(
+                self._stopped_by_user_message(pipeline) for pipeline in pipelines
+            )
         for pipeline in pipelines:
             pipeline.shutdown()
         logger.info(f"Stopped {len(pipelines)} posthoc pipeline(s)")
@@ -207,7 +227,10 @@ class PosthocPipelineManager(PipelineManagerABC):
         logger.info("PosthocPipelineManager: all pipelines shut down")
 
     def get_progress_updates(self) -> list[PipelineProgressMessage]:
-        progress_messages: list[PipelineProgressMessage] = []
+        with self.lock:
+            stop_messages, self.pending_stop_messages = self.pending_stop_messages, []
+
+        progress_messages: list[PipelineProgressMessage] = list(stop_messages)
 
         for pipeline in self.pipelines.values():
             progress_messages.extend(pipeline.get_progress_messages())


### PR DESCRIPTION
Fixes #829 - has the backend send a websocket message when the user stops a pipeline, mirroring the pattern when the pipeline finishes successfully on its own.


<img width="516" height="561" alt="Screenshot 2026-08-08 at 7 36 46 PM" src="https://github.com/user-attachments/assets/87d3d1b4-e801-4d25-943f-99f555eadc63" />
