### PR TITLE
Hide ceres calibration until ready

### DIFF
--- a/freemocap-ui/src/components/pipeline-progress/calibration-progress/calibration-settings.tsx
+++ b/freemocap-ui/src/components/pipeline-progress/calibration-progress/calibration-settings.tsx
@@ -45,8 +45,16 @@ interface CalibrationSettingsProps {
 
 const CalibrationSettings = ({ onClose }: CalibrationSettingsProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
-  const { config, updateCalibrationConfig } = useCalibration();
+  const { config, updateCalibrationConfig, pyceresAvailable } = useCalibration();
   const board = config.charucoBoard;
+
+  const solverOptions = useMemo(
+    () =>
+      pyceresAvailable === false
+        ? PRESET_OPTIONS_SOLVER.filter((label) => label !== "Accurate")
+        : PRESET_OPTIONS_SOLVER,
+    [pyceresAvailable],
+  );
 
   const handleClose = useCallback(() => {
     if (onClose) onClose();
@@ -243,17 +251,24 @@ const CalibrationSettings = ({ onClose }: CalibrationSettingsProps) => {
 
         <SubactionHeader text="Solver settings" />
 
-        {/* Method dropdown */}
-        <div className="flex p-1 flex-row gap-1 items-center justify-content-space-between">
-          <span className="text-sm">Method</span>
-          <NameDropdownSelector
-            key={config.solverMethod}
-            options={PRESET_OPTIONS_SOLVER}
-            initialValue={solverMethodToLabel[config.solverMethod]}
-            onChange={handleSolverChange}
-            className="flex flex-row"
-          />
-        </div>
+        {/* Method dropdown (only shown when there's a choice to make) */}
+        {solverOptions.length > 1 ? (
+          <div className="flex p-1 flex-row gap-1 items-center justify-content-space-between">
+            <span className="text-sm">Method</span>
+            <NameDropdownSelector
+              key={config.solverMethod}
+              options={solverOptions}
+              initialValue={solverMethodToLabel[config.solverMethod]}
+              onChange={handleSolverChange}
+              className="flex flex-row"
+            />
+          </div>
+        ) : (
+          <div className="flex p-1 flex-row gap-1 items-center justify-content-space-between">
+            <span className="text-sm">Method</span>
+            <span className="text-sm">{solverMethodToLabel[config.solverMethod]}</span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/freemocap-ui/src/constants/server-urls.ts
+++ b/freemocap-ui/src/constants/server-urls.ts
@@ -80,6 +80,7 @@ class ServerUrls {
             calibrationStartRecording: `${baseUrl}/freemocap/calibration/recording/start`,
             calibrationStopRecording: `${baseUrl}/freemocap/calibration/recording/stop`,
             calibrateRecording: `${baseUrl}/freemocap/calibration/recording/calibrate`,
+            calibrationPyceresAvailability: `${baseUrl}/freemocap/calibration/solver-methods/pyceres-availability`,
 
             // Mocap endpoints
             mocapStartRecording: `${baseUrl}/freemocap/mocap/recording/start`,

--- a/freemocap-ui/src/hooks/useCalibration.ts
+++ b/freemocap-ui/src/hooks/useCalibration.ts
@@ -1,5 +1,5 @@
 // hooks/useCalibration.ts
-import {useCallback} from 'react';
+import {useCallback, useEffect} from 'react';
 import {useAppDispatch, useAppSelector} from '@/store/hooks';
 import {store} from '@/store';
 import {useElectronIPC} from '@/services';
@@ -10,6 +10,7 @@ import {
     CalibrationDirectoryInfo,
     calibrationDirectoryInfoUpdated,
     calibrationErrorCleared,
+    checkPyceresAvailability,
     selectCalibration,
     selectCalibrationDirectoryInfo,
     selectCalibrationRecordingPath,
@@ -49,6 +50,12 @@ export function useCalibration() {
     const calibrationRecordingPath = useAppSelector(selectCalibrationRecordingPath);
     const directoryInfo = useAppSelector(selectCalibrationDirectoryInfo);
     const isUsingManualPath = useAppSelector(selectIsUsingManualCalibrationPath);
+
+    useEffect(() => {
+        if (calibrationState.pyceresAvailable === null && !calibrationState.isCheckingPyceresAvailability) {
+            void dispatch(checkPyceresAvailability());
+        }
+    }, [dispatch, calibrationState.pyceresAvailable, calibrationState.isCheckingPyceresAvailability]);
 
     const updateCalibrationConfig = useCallback(
         (updates: Partial<CalibrationConfig>) => {
@@ -127,6 +134,7 @@ export function useCalibration() {
         isUsingManualPath,
         canStartRecording,
         canCalibrate,
+        pyceresAvailable: calibrationState.pyceresAvailable,
         // Actions
         updateCalibrationConfig,
         setManualRecordingPath,

--- a/freemocap-ui/src/store/slices/calibration/calibration-slice.ts
+++ b/freemocap-ui/src/store/slices/calibration/calibration-slice.ts
@@ -3,6 +3,7 @@ import {RootState} from '../../types';
 import {loadFromStorage} from '@/store/persistence';
 import {
     calibrateRecording,
+    checkPyceresAvailability,
     loadCalibrationForRecording,
     loadCalibrationToml,
     startCalibrationRecording,
@@ -43,6 +44,8 @@ export interface CalibrationState {
     directoryInfo: CalibrationDirectoryInfo | null;
     loadedCalibration: LoadedCalibration | null;
     dismissedCalibrationPath: string | null;
+    pyceresAvailable: boolean | null;
+    isCheckingPyceresAvailability: boolean;
 }
 
 const DEFAULT_CALIBRATION_CONFIG: CalibrationConfig = {
@@ -64,6 +67,8 @@ const initialState: CalibrationState = {
     directoryInfo: null,
     loadedCalibration: null,
     dismissedCalibrationPath: null,
+    pyceresAvailable: null,
+    isCheckingPyceresAvailability: false,
 };
 
 export const calibrationSlice = createSlice({
@@ -158,6 +163,22 @@ export const calibrationSlice = createSlice({
                 state.isLoading = false;
                 state.error = action.payload || 'Failed to calibrate recording';
             });
+
+        builder
+            .addCase(checkPyceresAvailability.pending, (state) => {
+                state.isCheckingPyceresAvailability = true;
+            })
+            .addCase(checkPyceresAvailability.fulfilled, (state, action) => {
+                state.isCheckingPyceresAvailability = false;
+                state.pyceresAvailable = action.payload.available;
+                if (!action.payload.available && state.config.solverMethod === 'pyceres') {
+                    state.config.solverMethod = 'anipose';
+                }
+            })
+            .addCase(checkPyceresAvailability.rejected, (state) => {
+                state.isCheckingPyceresAvailability = false;
+                state.pyceresAvailable = false;
+            });
     },
 });
 
@@ -170,6 +191,7 @@ export const selectCalibrationError = (state: RootState) => state.calibration.er
 export const selectCalibrationDirectoryInfo = (state: RootState) => state.calibration.directoryInfo;
 export const selectLoadedCalibration = (state: RootState) => state.calibration.loadedCalibration;
 export const selectDismissedCalibrationPath = (state: RootState) => state.calibration.dismissedCalibrationPath;
+export const selectPyceresAvailable = (state: RootState) => state.calibration.pyceresAvailable;
 
 export const selectCalibrationRecordingPath = selectActiveRecordingFullPath;
 

--- a/freemocap-ui/src/store/slices/calibration/calibration-thunks.ts
+++ b/freemocap-ui/src/store/slices/calibration/calibration-thunks.ts
@@ -8,6 +8,30 @@ import type {LoadedCalibration} from "./calibration-slice";
 import {pipelineProgressUpdated, PipelinePhase, PipelineType} from "@/store/slices/pipelines";
 import {getTimestampString} from "@/store/slices/recording/getTimestampString";
 
+export const checkPyceresAvailability = createAsyncThunk<
+    { available: boolean; message?: string | null },
+    void,
+    { state: RootState; rejectValue: string }
+>(
+    'calibration/checkPyceresAvailability',
+    async (_, { rejectWithValue }) => {
+        try {
+            const response = await fetch(serverUrls.endpoints.calibrationPyceresAvailability);
+            if (!response.ok) {
+                return rejectWithValue(await getDetailedErrorMessage(response));
+            }
+            const data = await response.json();
+            return {
+                available: !!data.available,
+                message: data.message ?? null,
+            };
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : 'Unknown error';
+            return rejectWithValue(msg);
+        }
+    }
+);
+
 export const loadCalibrationForRecording = createAsyncThunk<
     LoadedCalibration | null,
     { recordingId: string; recordingParentDirectory?: string | null },

--- a/freemocap/api/http/calibration/calibration_router.py
+++ b/freemocap/api/http/calibration/calibration_router.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import logging
 from copy import deepcopy
@@ -85,6 +86,11 @@ class CalibrateRecordingResponse(BaseModel):
     message: str | None = None
     results: dict | None = None
     pipeline_id: str | None = None
+
+
+class PyceresAvailabilityResponse(BaseModel):
+    available: bool
+    message: str | None = None
 
 
 # ==================== Helpers ====================
@@ -227,6 +233,17 @@ async def stop_calibration_recording(
     except Exception as e:
         logger.exception(f"Error stopping calibration recording: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@calibration_router.get("/solver-methods/pyceres-availability")
+def get_pyceres_availability() -> PyceresAvailabilityResponse:
+    """Check whether the optional `pyceres` package (required by the 'Accurate' solver) is installed."""
+    if importlib.util.find_spec("pyceres") is not None:
+        return PyceresAvailabilityResponse(available=True)
+    return PyceresAvailabilityResponse(
+        available=False,
+        message="The 'pyceres' package is not installed in this environment.",
+    )
 
 
 @calibration_router.post("/recording/calibrate")

--- a/freemocap/core/tasks/calibration/posthoc_calibration_task.py
+++ b/freemocap/core/tasks/calibration/posthoc_calibration_task.py
@@ -176,7 +176,14 @@ def _run_pyceres_path(
         video_metadata: dict[CameraIdString, VideoMetadata],
 ) -> tuple[CalibrationResult, GroundPlaneResult | None]:
     """Run calibration using the pyceres bundle adjustment solver."""
-    from freemocap.core.tasks.calibration.pyceres_calibration.pyceres_calibration_pipeline import run_pyceres_calibration
+    try:
+        from freemocap.core.tasks.calibration.pyceres_calibration.pyceres_calibration_pipeline import run_pyceres_calibration
+    except ImportError as e:
+        raise RuntimeError(
+            "The 'Accurate' calibration solver requires the optional `pyceres` package, "
+            "which is not installed in this environment. Install it with "
+            "`uv sync --group pyceres`, or select the 'Anipose legacy' solver instead."
+        ) from e
 
     if len(all_observations) == 0:
         raise ValueError("No valid charuco observations found")


### PR DESCRIPTION
The pyceres based calibration method is currently untested, and we don't bundle pyceres with the app. This means there is a calibration method option where one option cannot run. This PR hides that option when ceres isn't available. This prevents confusion among users for now, and will show the option as soon as we choose to bundle ceres. 