### PR TITLE
Add backward-compatible two-performer realtime payload

### DIFF
--- a/.github/workflows/mivubi-multi-person.yml
+++ b/.github/workflows/mivubi-multi-person.yml
@@ -1,0 +1,27 @@
+name: Mivubi multi-person regression
+
+on:
+  push:
+    branches: [feature/mivubi-multi-person]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.12.5"
+          enable-cache: true
+      - run: uv sync --frozen --no-default-groups --group cpu --group dev
+      - run: uv run --no-sync ruff check freemocap/
+      - run: >-
+          uv run --no-sync pytest -q
+          freemocap/tests/test_binary_keypoints_protocol.py
+          freemocap/tests/test_multi_person_association.py
+          freemocap/tests/triangulation/test_outlier_rejection.py

--- a/.github/workflows/mivubi-multi-person.yml
+++ b/.github/workflows/mivubi-multi-person.yml
@@ -19,7 +19,14 @@ jobs:
           version: "0.12.5"
           enable-cache: true
       - run: uv sync --frozen --no-default-groups --group cpu --group dev
-      - run: uv run --no-sync ruff check freemocap/
+      - run: >-
+          uv run --no-sync ruff check
+          freemocap/core/tracking/multi_person_association.py
+          freemocap/core/viz/frontend_keypoints_serializer.py
+          freemocap/core/pipeline/realtime/realtime_pipeline.py
+          freemocap/pubsub/pubsub_topics.py
+          freemocap/tests/test_binary_keypoints_protocol.py
+          freemocap/tests/test_multi_person_association.py
       - run: >-
           uv run --no-sync pytest -q
           freemocap/tests/test_binary_keypoints_protocol.py

--- a/.github/workflows/mivubi-multi-person.yml
+++ b/.github/workflows/mivubi-multi-person.yml
@@ -22,13 +22,20 @@ jobs:
       - run: >-
           uv run --no-sync ruff check
           freemocap/core/tracking/multi_person_association.py
+          freemocap/core/pipeline/realtime/camera_node_config.py
+          freemocap/core/pipeline/realtime/realtime_aggregator_node.py
+          freemocap/core/pipeline/realtime/realtime_skeleton_inference_node.py
           freemocap/core/viz/frontend_keypoints_serializer.py
+          freemocap/core/viz/frontend_payload.py
+          freemocap/api/http/calibration/calibration_router.py
           freemocap/core/pipeline/realtime/realtime_pipeline.py
           freemocap/pubsub/pubsub_topics.py
           freemocap/tests/test_binary_keypoints_protocol.py
           freemocap/tests/test_multi_person_association.py
+          freemocap/tests/http/test_calibration_router_recording_state.py
       - run: >-
           uv run --no-sync pytest -q
           freemocap/tests/test_binary_keypoints_protocol.py
           freemocap/tests/test_multi_person_association.py
+          freemocap/tests/http/test_calibration_router_recording_state.py
           freemocap/tests/triangulation/test_outlier_rejection.py

--- a/freemocap/api/http/calibration/calibration_router.py
+++ b/freemocap/api/http/calibration/calibration_router.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import logging
+import os
 from copy import deepcopy
 from pathlib import Path
 
@@ -10,16 +11,24 @@ from skellycam.core.recorders.videos.parse_video_filename import VIDEO_EXTENSION
 from skellycam.core.recorders.videos.recording_info import RecordingInfo
 
 from freemocap.app.freemocap_application import get_freemocap_app
-from freemocap.core.tasks.calibration.calibration_task_config import PosthocCalibrationPipelineConfig
+from freemocap.core.tasks.calibration.calibration_task_config import (
+    PosthocCalibrationPipelineConfig,
+)
 from freemocap.pubsub.pubsub_topics import (
     CalibrationRecordingStateMessage,
     CalibrationRecordingStateTopic,
 )
 from freemocap.system.default_paths import FREEMOCAP_TEST_DATA_PATH
+from freemocap.core.tasks.calibration.shared.calibration_paths import (
+    get_last_successful_calibration_toml_path,
+)
+from freemocap.core.tasks.calibration.shared.calibration_result import CalibrationResult
 
 logger = logging.getLogger(__name__)
 
-calibration_router = APIRouter(prefix="/calibration", tags=["Capture Volume Calibration"])
+calibration_router = APIRouter(
+    prefix="/calibration", tags=["Capture Volume Calibration"]
+)
 
 
 # ==================== Request/Response Models ====================
@@ -35,7 +44,9 @@ class CalibrationConfigResponse(BaseModel):
 
 
 def _calibrate_request_schema_extra(schema: dict) -> None:
-    schema["examples"] = [CalibrateRecordingRequest.create_test_data_request().model_dump(by_alias=True)]
+    schema["examples"] = [
+        CalibrateRecordingRequest.create_test_data_request().model_dump(by_alias=True)
+    ]
 
 
 class CalibrateRecordingRequest(BaseModel):
@@ -49,11 +60,14 @@ class CalibrateRecordingRequest(BaseModel):
     )
     calibration_recording_directory: str | None = Field(
         alias="calibrationRecordingDirectory",
-        description="Optional directory for calibration recording, if None/null use most recent successful recording", )
+        description="Optional directory for calibration recording, if None/null use most recent successful recording",
+    )
 
     def to_recording_info(self) -> RecordingInfo:
         if self.calibration_recording_directory is None:
-            raise RuntimeError("CalibrationConfig.calibration_recording_directory not set")
+            raise RuntimeError(
+                "CalibrationConfig.calibration_recording_directory not set"
+            )
         recording_dir = Path(self.calibration_recording_directory).expanduser()
         return RecordingInfo(
             recording_directory=str(recording_dir.parent),
@@ -68,12 +82,16 @@ class CalibrateRecordingRequest(BaseModel):
         config.charuco_board.squares_x = 7
         config.charuco_board.squares_y = 5
         config.charuco_board.square_length_mm = 54
-        return cls(calibration_config=config,
-                   calibration_recording_directory=FREEMOCAP_TEST_DATA_PATH)
+        return cls(
+            calibration_config=config,
+            calibration_recording_directory=FREEMOCAP_TEST_DATA_PATH,
+        )
 
 
 class StopCalibrationRecordingRequest(BaseModel):
-    calibration_config: PosthocCalibrationPipelineConfig = Field(alias="calibrationTaskConfig")
+    calibration_config: PosthocCalibrationPipelineConfig = Field(
+        alias="calibrationTaskConfig"
+    )
 
 
 class StartCalibrationRecordingResponse(BaseModel):
@@ -91,6 +109,16 @@ class CalibrateRecordingResponse(BaseModel):
 class PyceresAvailabilityResponse(BaseModel):
     available: bool
     message: str | None = None
+
+
+class CalibrationStatusResponse(BaseModel):
+    state: str
+    path: str | None = None
+    camera_ids: list[str] = Field(default_factory=list)
+    reprojection_error_px: float | None = None
+    accepted: bool = False
+    updated_at_ms: int | None = None
+    error: str | None = None
 
 
 # ==================== Helpers ====================
@@ -116,7 +144,8 @@ def _reject_if_recording_directory_not_empty(recording_info: RecordingInfo) -> N
     if not videos_dir.is_dir():
         return
     existing_videos = sorted(
-        p for p in videos_dir.iterdir()
+        p
+        for p in videos_dir.iterdir()
         if p.is_file() and p.suffix.lower() in VIDEO_EXTENSIONS
     )
     if existing_videos:
@@ -135,9 +164,32 @@ def _reject_if_recording_directory_not_empty(recording_info: RecordingInfo) -> N
 # ==================== Endpoints ====================
 
 
+@calibration_router.get("/status")
+def get_calibration_status() -> CalibrationStatusResponse:
+    path = get_last_successful_calibration_toml_path()
+    if not path.is_file():
+        return CalibrationStatusResponse(state="missing")
+    try:
+        calibration = CalibrationResult.load_anipose_toml(path)
+        error_px = float(calibration.reprojection_error_px)
+        return CalibrationStatusResponse(
+            state="ready",
+            path=str(path),
+            camera_ids=calibration.camera_ids,
+            reprojection_error_px=error_px,
+            accepted=error_px <= 2.0,
+            updated_at_ms=int(os.path.getmtime(path) * 1000),
+        )
+    except Exception as error:
+        logger.exception("Unable to load last successful calibration")
+        return CalibrationStatusResponse(
+            state="invalid", path=str(path), error=str(error)
+        )
+
+
 @calibration_router.post("/recording/start")
 async def start_calibration_recording(
-        request: CalibrateRecordingRequest,
+    request: CalibrateRecordingRequest,
 ) -> StartCalibrationRecordingResponse:
     """Start calibration recording with given config."""
     try:
@@ -174,7 +226,9 @@ async def start_calibration_recording(
                         f"[{pipeline.id}] — continuing with skeleton inference on"
                     )
 
-        return StartCalibrationRecordingResponse(success=True, message="Recording started")
+        return StartCalibrationRecordingResponse(
+            success=True, message="Recording started"
+        )
     except HTTPException:
         raise
     except Exception as e:
@@ -184,7 +238,7 @@ async def start_calibration_recording(
 
 @calibration_router.post("/recording/stop")
 async def stop_calibration_recording(
-        request: StopCalibrationRecordingRequest,
+    request: StopCalibrationRecordingRequest,
 ) -> dict:
     """Stop current calibration recording and launch posthoc calibration pipeline."""
     app = get_freemocap_app()
@@ -218,12 +272,16 @@ async def stop_calibration_recording(
                         f"[{pipeline.id}]"
                     )
 
-        logger.info(f"Recording stopped - saved to: {recording_info.full_recording_path}")
+        logger.info(
+            f"Recording stopped - saved to: {recording_info.full_recording_path}"
+        )
         pipeline = await app.create_posthoc_calibration_pipeline(
             recording_info=recording_info,
             calibration_config=request.calibration_config,
         )
-        logger.info("Calibration recording stopped, posthoc calibration pipeline launched")
+        logger.info(
+            "Calibration recording stopped, posthoc calibration pipeline launched"
+        )
         return {
             "success": True,
             "pipeline_id": pipeline.id,
@@ -247,17 +305,20 @@ def get_pyceres_availability() -> PyceresAvailabilityResponse:
 
 
 @calibration_router.post("/recording/calibrate")
-async def calibrate_recording(request: CalibrateRecordingRequest) -> CalibrateRecordingResponse:
+async def calibrate_recording(
+    request: CalibrateRecordingRequest,
+) -> CalibrateRecordingResponse:
     """Process and calibrate a previously recorded session."""
     app = get_freemocap_app()
     try:
-
         recording_info = request.to_recording_info()
         pipeline = await app.create_posthoc_calibration_pipeline(
             recording_info=recording_info,
             calibration_config=request.calibration_config,
         )
-        logger.info(f"Calibrating recording at: {recording_info.full_recording_path} with calibration config:\n {request.calibration_config.model_dump_json(indent=2)}")
+        logger.info(
+            f"Calibrating recording at: {recording_info.full_recording_path} with calibration config:\n {request.calibration_config.model_dump_json(indent=2)}"
+        )
         return CalibrateRecordingResponse(
             success=True,
             message="Calibration pipeline launched",

--- a/freemocap/core/pipeline/realtime/camera_node_config.py
+++ b/freemocap/core/pipeline/realtime/camera_node_config.py
@@ -10,8 +10,12 @@ from skellytracker.core.detectors.keypoint_detectors.charuco import (
 from skellytracker.core.detectors.keypoint_detectors.mediapipe.mediapipe_model_manager import (
     MediapipePoseModelComplexity,
 )
-from skellytracker.core.detectors.keypoint_detectors.rtmpose import RTMPoseDetectorConfig
-from skellytracker.core.detectors.object_detectors.yolox import YoloxPersonDetectorConfig
+from skellytracker.core.detectors.keypoint_detectors.rtmpose import (
+    RTMPoseDetectorConfig,
+)
+from skellytracker.core.detectors.object_detectors.yolox import (
+    YoloxPersonDetectorConfig,
+)
 from skellytracker.core.temporal_processing.temporal_processing_config import (
     BBoxPolicyConfig,
     BBoxSmoothingConfig,
@@ -23,7 +27,10 @@ _REDETECT_SECONDS = 5.0
 _ASSUMED_CAMERA_FPS = 30.0
 
 
-def _default_skeleton_tracker_config() -> TrackerConfig:
+def _skeleton_tracker_config(
+    model_name: str = "rtmw-x-l_256x192",
+    confidence_threshold: float = 0.0025,
+) -> TrackerConfig:
     redetect_interval = max(1, round(_REDETECT_SECONDS * _ASSUMED_CAMERA_FPS))
     return TrackerConfig(
         stages=[
@@ -32,8 +39,8 @@ def _default_skeleton_tracker_config() -> TrackerConfig:
                 object_detector=YoloxPersonDetectorConfig(),
                 keypoint_detectors=[
                     RTMPoseDetectorConfig(
-                        model_name="rtmw-x-l_256x192",
-                        confidence_threshold=0.0025,
+                        model_name=model_name,
+                        confidence_threshold=confidence_threshold,
                     )
                 ],
                 bbox_policy=BBoxPolicyConfig(
@@ -47,6 +54,10 @@ def _default_skeleton_tracker_config() -> TrackerConfig:
             )
         ]
     )
+
+
+def _default_skeleton_tracker_config() -> TrackerConfig:
+    return _skeleton_tracker_config()
 
 
 def _charuco_tracker_config_for_board(board: CharucoBoardDefinition) -> TrackerConfig:
@@ -64,12 +75,18 @@ class CameraNodeConfig(BaseModel):
     worker_mode: WorkerMode = WorkerMode.PROCESS
     charuco_tracking_enabled: bool = True
     skeleton_tracking_enabled: bool = True
+    multi_person_enabled: bool = False
+    max_persons: int = Field(default=2, ge=1, le=2)
     detector_type: Literal["rtmpose", "mediapipe"] = "rtmpose"
     # RTMPose config (only used when detector_type="rtmpose")
-    rtmpose_model_name: Literal["rtmw-x-l_256x192", "rtmw-x-l_384x288", "rtmw-l-m_256x192"] = "rtmw-x-l_256x192"
+    rtmpose_model_name: Literal[
+        "rtmw-x-l_256x192", "rtmw-x-l_384x288", "rtmw-l-m_256x192"
+    ] = "rtmw-x-l_256x192"
     rtmpose_confidence_threshold: float = 0.0025
     # MediaPipe config (only used when detector_type="mediapipe")
-    mediapipe_model_complexity: MediapipePoseModelComplexity = MediapipePoseModelComplexity.LITE
+    mediapipe_model_complexity: MediapipePoseModelComplexity = (
+        MediapipePoseModelComplexity.LITE
+    )
     mediapipe_detection_confidence: float = 0.5
     mediapipe_presence_confidence: float = 0.5
     mediapipe_tracking_confidence: float = 0.5
@@ -119,5 +136,16 @@ class CameraNodeConfig(BaseModel):
         RealtimePipeline, posthoc video_node reprocessing) reads the board out
         of via stages[0].keypoint_detectors[0].board.
         """
-        self.charuco_tracker_config = _charuco_tracker_config_for_board(self.charuco_board)
+        self.charuco_tracker_config = _charuco_tracker_config_for_board(
+            self.charuco_board
+        )
+        if self.multi_person_enabled and self.detector_type != "rtmpose":
+            raise ValueError(
+                "Multi-person realtime tracking currently requires detector_type='rtmpose'."
+            )
+        if self.multi_person_enabled:
+            self.skeleton_tracker_config = _skeleton_tracker_config(
+                model_name=self.rtmpose_model_name,
+                confidence_threshold=self.rtmpose_confidence_threshold,
+            )
         return self

--- a/freemocap/core/pipeline/realtime/realtime_aggregator_node.py
+++ b/freemocap/core/pipeline/realtime/realtime_aggregator_node.py
@@ -19,6 +19,7 @@ enforced by a single closed-form forward pass. Only real (non-extrapolated)
 keypoints teach lengths. The reset signal clears the rolling window so the next
 ~window seconds re-fit from scratch.
 """
+
 import logging
 import multiprocessing.synchronize
 import queue
@@ -50,20 +51,37 @@ from skellycam.core.ipc.shared_memory.camera_group_shared_memory import (
     CameraGroupSharedMemory,
     CameraGroupSharedMemoryDTO,
 )
-from skellycam.core.types.type_overloads import CameraGroupIdString, CameraIdString, TopicSubscriptionQueue
+from skellycam.core.types.type_overloads import (
+    CameraGroupIdString,
+    CameraIdString,
+    TopicSubscriptionQueue,
+)
 from skellyforge.data_models.trajectory_3d import Point3d
 
 from freemocap.core.pipeline.abcs.aggregator_node_abc import AggregatorNode
 from freemocap.core.pipeline.abcs.pipeline_ipc import PipelineIPC
-from freemocap.core.pipeline.realtime.realtime_pipeline_config import RealtimePipelineConfig
+from freemocap.core.pipeline.realtime.realtime_pipeline_config import (
+    RealtimePipelineConfig,
+)
 from freemocap.core.pipeline.pipeline_stage_timer import PipelineStageTimer
 from freemocap.core.pipeline.pipeline_timing_reporter import PipelineTimingReporter
-from freemocap.core.tasks.calibration.shared.calibration_state import CalibrationStateTracker
-from freemocap.core.tasks.triangulation.helpers.angulation_result import AngulationResult
-from freemocap.core.tasks.mocap.realtime_filtering.realtime_point_gate import RealtimePointGate, \
-    GateResult
-from freemocap.core.tasks.mocap.realtime_filtering.realtime_filter_config import RealtimeFilterConfig
-from freemocap.core.pipeline.realtime.realtime_keypoint_filter import RealtimeKeypointFilter
+from freemocap.core.tasks.calibration.shared.calibration_state import (
+    CalibrationStateTracker,
+)
+from freemocap.core.tasks.triangulation.helpers.angulation_result import (
+    AngulationResult,
+)
+from freemocap.core.tasks.mocap.realtime_filtering.realtime_point_gate import (
+    RealtimePointGate,
+    GateResult,
+)
+from freemocap.core.pipeline.realtime.realtime_keypoint_filter import (
+    RealtimeKeypointFilter,
+)
+from freemocap.core.tracking.multi_person_association import (
+    CrossCameraAssociator,
+    observation_descriptor,
+)
 from freemocap.core.types.type_overloads import TopicPublicationQueue
 from freemocap.pubsub.pubsub_manager import PubSubTopicManager
 from freemocap.pubsub.pubsub_topics import (
@@ -78,6 +96,10 @@ from freemocap.pubsub.pubsub_topics import (
     SkeletonInferenceResultMessage,
     SkeletonInferenceResultTopic,
     PipelineTimingTopic,
+)
+
+from freemocap.core.tasks.mocap.realtime_filtering.realtime_filter_config import (
+    RealtimeFilterConfig,  # noqa: TC001
 )
 
 # Cap on how many pending skeleton-inference results we hold while waiting for
@@ -99,11 +121,12 @@ logger = logging.getLogger(__name__)
 # How often (seconds) to poll the calibration file for changes
 CALIBRATION_POLL_INTERVAL_SECONDS: float = 1.0
 
+
 def _merge_angulation(
-        *,
-        angulation: AngulationResult | None,
-        into_points: dict[str, np.ndarray],
-        into_errors: dict[str, float],
+    *,
+    angulation: AngulationResult | None,
+    into_points: dict[str, np.ndarray],
+    into_errors: dict[str, float],
 ) -> None:
     """Merge one frame's triangulated points and their reprojection errors into
     the output dicts, skipping NaN entries. Error-less results (single-camera
@@ -125,21 +148,20 @@ def _merge_angulation(
 
 @dataclass
 class RealtimeAggregatorNode(AggregatorNode):
-
     @classmethod
     def create(
-            cls,
-            *,
-            config: RealtimePipelineConfig,
-            camera_group_id: CameraGroupIdString,
-            camera_ids: list[CameraIdString],
-            worker_registry: WorkerRegistry,
-            camera_group_shm_dto: CameraGroupSharedMemoryDTO,
-            ipc: PipelineIPC,
-            pubsub: PubSubTopicManager,
-            result_ready_event: multiprocessing.synchronize.Event,
-            result_consumed_event: multiprocessing.synchronize.Event,
-            skeleton_fitter_reset_sub: TopicSubscriptionQueue,
+        cls,
+        *,
+        config: RealtimePipelineConfig,
+        camera_group_id: CameraGroupIdString,
+        camera_ids: list[CameraIdString],
+        worker_registry: WorkerRegistry,
+        camera_group_shm_dto: CameraGroupSharedMemoryDTO,
+        ipc: PipelineIPC,
+        pubsub: PubSubTopicManager,
+        result_ready_event: multiprocessing.synchronize.Event,
+        result_consumed_event: multiprocessing.synchronize.Event,
+        skeleton_fitter_reset_sub: TopicSubscriptionQueue,
     ) -> "RealtimeAggregatorNode":
         shutdown_self_flag, worker = cls._create_worker(
             target=cls._run,
@@ -172,7 +194,9 @@ class RealtimeAggregatorNode(AggregatorNode):
                 ),
                 timing_sub=pubsub.get_subscription(
                     PipelineTimingTopic,
-                ) if config.log_pipeline_times else None,
+                )
+                if config.log_pipeline_times
+                else None,
                 result_ready_event=result_ready_event,
                 result_consumed_event=result_consumed_event,
                 skeleton_fitter_reset_sub=skeleton_fitter_reset_sub,
@@ -185,23 +209,23 @@ class RealtimeAggregatorNode(AggregatorNode):
 
     @staticmethod
     def _run(
-            *,
-            pipeline_config: RealtimePipelineConfig,
-            camera_group_id: CameraGroupIdString,
-            camera_ids: list[CameraIdString],
-            ipc: PipelineIPC,
-            shutdown_self_flag: Synchronized,
-            camera_group_shm_dto: CameraGroupSharedMemoryDTO,
-            camera_node_sub: TopicSubscriptionQueue,
-            skeleton_inference_sub: TopicSubscriptionQueue,
-            pipeline_config_sub: TopicSubscriptionQueue,
-            process_frame_number_pub: TopicPublicationQueue,
-            aggregation_output_pub: TopicPublicationQueue,
-            timing_pub: TopicPublicationQueue,
-            timing_sub: TopicSubscriptionQueue | None,
-            result_ready_event: multiprocessing.synchronize.Event,
-            result_consumed_event: multiprocessing.synchronize.Event,
-            skeleton_fitter_reset_sub: TopicSubscriptionQueue,
+        *,
+        pipeline_config: RealtimePipelineConfig,
+        camera_group_id: CameraGroupIdString,
+        camera_ids: list[CameraIdString],
+        ipc: PipelineIPC,
+        shutdown_self_flag: Synchronized,
+        camera_group_shm_dto: CameraGroupSharedMemoryDTO,
+        camera_node_sub: TopicSubscriptionQueue,
+        skeleton_inference_sub: TopicSubscriptionQueue,
+        pipeline_config_sub: TopicSubscriptionQueue,
+        process_frame_number_pub: TopicPublicationQueue,
+        aggregation_output_pub: TopicPublicationQueue,
+        timing_pub: TopicPublicationQueue,
+        timing_sub: TopicSubscriptionQueue | None,
+        result_ready_event: multiprocessing.synchronize.Event,
+        result_consumed_event: multiprocessing.synchronize.Event,
+        skeleton_fitter_reset_sub: TopicSubscriptionQueue,
     ) -> None:
         logger.debug(f"RealtimeAggregationNode [{camera_group_id}] initializing")
         aggregator_config = pipeline_config.aggregator_config
@@ -211,7 +235,9 @@ class RealtimeAggregatorNode(AggregatorNode):
         )
         _configured_calib_path = aggregator_config.calibration_toml_path
         calibration = CalibrationStateTracker.create_and_try_load(
-            calibration_toml_path=Path(_configured_calib_path) if _configured_calib_path else None,
+            calibration_toml_path=Path(_configured_calib_path)
+            if _configured_calib_path
+            else None,
         )
         if calibration.is_valid:
             logger.info(
@@ -276,6 +302,10 @@ class RealtimeAggregatorNode(AggregatorNode):
         # by the centralized SkeletonInferenceNode (when GPU mode is on);
         # consumed when the matching camera outputs arrive for that frame.
         pending_skeleton_results: dict[int, dict[CameraIdString, object | None]] = {}
+        pending_multi_person_results: dict[
+            int, dict[CameraIdString, dict[str, object]]
+        ] = {}
+        cross_camera_associator = CrossCameraAssociator()
         # Wall-clock time we started waiting on the currently-expected frame's
         # skeleton result; None when not waiting. Reset whenever the wait
         # resolves (found, or times out and is abandoned).
@@ -285,7 +315,11 @@ class RealtimeAggregatorNode(AggregatorNode):
         last_calibration_poll: float = time.perf_counter()
         _empty_3d_logged: bool = False  # Rate-limit the "no 3D keypoints" warning
         log_pipeline_times = pipeline_config.log_pipeline_times
-        timer = PipelineStageTimer(name=f"AggregatorNode-{camera_group_id}") if log_pipeline_times else None
+        timer = (
+            PipelineStageTimer(name=f"AggregatorNode-{camera_group_id}")
+            if log_pipeline_times
+            else None
+        )
         t_frame_requested: float = time.perf_counter() if timer is not None else 0.0
         # Skip the first frame_collection_wait / loop_time samples — those
         # measure aggregator-startup → first-frame-arrival, which is dominated
@@ -319,12 +353,16 @@ class RealtimeAggregatorNode(AggregatorNode):
 
         try:
             previous_loop_tik = time.perf_counter() if timer is not None else 0.0
-            logger.debug(f"RealtimeAggregationNode [{camera_group_id}] entering main loop")
+            logger.debug(
+                f"RealtimeAggregationNode [{camera_group_id}] entering main loop"
+            )
             while ipc.should_continue and not shutdown_self_flag.value:
                 # ---- Handle config updates ----
                 while True:
                     try:
-                        msg: PipelineConfigUpdateMessage = pipeline_config_sub.get_nowait()
+                        msg: PipelineConfigUpdateMessage = (
+                            pipeline_config_sub.get_nowait()
+                        )
                     except queue.Empty:
                         break
                     pipeline_config = msg.pipeline_config
@@ -439,32 +477,45 @@ class RealtimeAggregatorNode(AggregatorNode):
                 # requested optimistically after camera collection completes (below).
                 # This block handles startup (latest_requested_frame == -1) and the
                 # rare case where the shm hadn't advanced at the optimistic-request point.
-                if (current_multiframe_number > latest_requested_frame
-                        and last_received_frame >= latest_requested_frame
-                        and result_consumed_event.is_set()):
+                if (
+                    current_multiframe_number > latest_requested_frame
+                    and last_received_frame >= latest_requested_frame
+                    and result_consumed_event.is_set()
+                ):
                     process_frame_number_pub.put(
                         ProcessFrameNumberMessage(
                             frame_number=current_multiframe_number,
                         ),
                     )
                     latest_requested_frame = current_multiframe_number
-                    t_frame_requested = time.perf_counter() if timer is not None else 0.0
+                    t_frame_requested = (
+                        time.perf_counter() if timer is not None else 0.0
+                    )
 
                 # ---- Collect skeleton inference results (GPU mode) ----
                 # Drained on every iteration so they're available whenever the
                 # corresponding camera-node charuco outputs finish arriving.
                 while True:
                     try:
-                        skel_msg: SkeletonInferenceResultMessage = skeleton_inference_sub.get_nowait()
+                        skel_msg: SkeletonInferenceResultMessage = (
+                            skeleton_inference_sub.get_nowait()
+                        )
                     except queue.Empty:
                         break
-                    pending_skeleton_results[skel_msg.frame_number] = skel_msg.per_camera_skeleton
+                    pending_skeleton_results[skel_msg.frame_number] = (
+                        skel_msg.per_camera_skeleton
+                    )
+                    pending_multi_person_results[skel_msg.frame_number] = (
+                        skel_msg.per_camera_people
+                    )
                 # Bound the pending dict so a lagging camera can't grow it forever.
                 if len(pending_skeleton_results) > _MAX_PENDING_SKELETON_RESULTS:
                     oldest = sorted(pending_skeleton_results.keys())[
-                             :len(pending_skeleton_results) - _MAX_PENDING_SKELETON_RESULTS]
+                        : len(pending_skeleton_results) - _MAX_PENDING_SKELETON_RESULTS
+                    ]
                     for k in oldest:
                         pending_skeleton_results.pop(k, None)
+                        pending_multi_person_results.pop(k, None)
 
                 # ---- Collect camera node outputs ----
                 # If camera outputs are already complete (we looped back waiting
@@ -479,7 +530,9 @@ class RealtimeAggregatorNode(AggregatorNode):
                     # busy-polling with empty() + 1ms sleep — cuts CPU waste
                     # and removes polling overhead from the critical path.
                     try:
-                        cam_output: CameraNodeOutputMessage = camera_node_sub.get(timeout=0.005)
+                        cam_output: CameraNodeOutputMessage = camera_node_sub.get(
+                            timeout=0.005
+                        )
                     except queue.Empty:
                         continue
                     if cam_output.camera_id not in camera_ids:
@@ -497,21 +550,28 @@ class RealtimeAggregatorNode(AggregatorNode):
                     camera_node_outputs[cam_output.camera_id] = cam_output
 
                     if not all(
-                            isinstance(v, CameraNodeOutputMessage)
-                            for v in camera_node_outputs.values()
+                        isinstance(v, CameraNodeOutputMessage)
+                        for v in camera_node_outputs.values()
                     ):
                         continue
 
                 # ---- In GPU mode, also wait for the skeleton inference result ----
-                if (pipeline_config.use_centralized_inference
-                        and pipeline_config.camera_node_config.skeleton_tracking_enabled):
-                    expected_frame = next(iter(camera_node_outputs.values())).frame_number
+                if (
+                    pipeline_config.use_centralized_inference
+                    and pipeline_config.camera_node_config.skeleton_tracking_enabled
+                ):
+                    expected_frame = next(
+                        iter(camera_node_outputs.values())
+                    ).frame_number
                     if expected_frame not in pending_skeleton_results:
                         now = time.perf_counter()
                         if skeleton_wait_started_at is None:
                             skeleton_wait_started_at = now
                             continue
-                        elif now - skeleton_wait_started_at > _SKELETON_RESULT_WAIT_TIMEOUT_SECONDS:
+                        elif (
+                            now - skeleton_wait_started_at
+                            > _SKELETON_RESULT_WAIT_TIMEOUT_SECONDS
+                        ):
                             # The result for this frame is never coming — most
                             # likely the SkeletonInferenceNode was restarted
                             # (e.g. detector swap) mid-flight and its pub/sub
@@ -536,10 +596,20 @@ class RealtimeAggregatorNode(AggregatorNode):
                         # Splice the per-camera skeletons into each CameraNodeOutputMessage
                         # so downstream triangulation code (which reads
                         # `output.skeleton_observation`) needs no changes.
-                        skeleton_per_camera = pending_skeleton_results.pop(expected_frame)
+                        skeleton_per_camera = pending_skeleton_results.pop(
+                            expected_frame
+                        )
+                        people_per_camera = pending_multi_person_results.pop(
+                            expected_frame, {}
+                        )
                         for cam_id, output_msg in camera_node_outputs.items():
                             if output_msg is not None:
-                                output_msg.skeleton_observation = skeleton_per_camera.get(cam_id)
+                                output_msg.skeleton_observation = (
+                                    skeleton_per_camera.get(cam_id)
+                                )
+                                output_msg.skeleton_observations = (
+                                    people_per_camera.get(cam_id, {})
+                                )
                         skeleton_wait_started_at = None
 
                 frame_numbers = [
@@ -556,7 +626,10 @@ class RealtimeAggregatorNode(AggregatorNode):
                 last_received_frame = latest_requested_frame
                 t_frame_start = time.perf_counter() if timer is not None else 0.0
                 if timer is not None and recorded_first_frame:
-                    timer.record("frame_collection_wait", (t_frame_start - t_frame_requested) * 1e3)
+                    timer.record(
+                        "frame_collection_wait",
+                        (t_frame_start - t_frame_requested) * 1e3,
+                    )
 
                 # ---- Optimistically request next frame before aggregating ----
                 # result_consumed_event is guaranteed set at this point: we checked it
@@ -570,7 +643,9 @@ class RealtimeAggregatorNode(AggregatorNode):
                         ProcessFrameNumberMessage(frame_number=latest_shm_frame)
                     )
                     latest_requested_frame = latest_shm_frame
-                    t_frame_requested = time.perf_counter() if timer is not None else 0.0
+                    t_frame_requested = (
+                        time.perf_counter() if timer is not None else 0.0
+                    )
                 elif latest_shm_frame < latest_requested_frame:
                     raise RuntimeError(
                         f"SHM frame counter went backwards: latest_shm_frame={latest_shm_frame} "
@@ -591,13 +666,59 @@ class RealtimeAggregatorNode(AggregatorNode):
                 xcom: Point3d | None = None
                 body_kinematics = None
                 rigid_result: RigidifyResult | None = None
-                if (calibration.is_valid or len(camera_ids) == 1) and aggregator_config.triangulation_enabled:
+                performer_skeletons: dict[str, dict[str, np.ndarray]] = {}
+                performer_camera_observations: dict[
+                    str, dict[CameraIdString, object]
+                ] = {}
+                if (
+                    calibration.is_valid or len(camera_ids) == 1
+                ) and aggregator_config.triangulation_enabled:
+                    if pipeline_config.camera_node_config.multi_person_enabled:
+                        descriptors = {
+                            cam_id: [
+                                observation_descriptor(track_id, observation)
+                                for track_id, observation in output.skeleton_observations.items()
+                            ]
+                            for cam_id, output in frame_n_outputs.items()
+                            if isinstance(output, CameraNodeOutputMessage)
+                            and output.skeleton_observations
+                        }
+                        assignments = cross_camera_associator.assign(descriptors)
+                        for performer_id, camera_tracks in assignments.items():
+                            observations = {
+                                cam_id: frame_n_outputs[cam_id].skeleton_observations[
+                                    track_id
+                                ]
+                                for cam_id, track_id in camera_tracks.items()
+                                if isinstance(
+                                    frame_n_outputs.get(cam_id), CameraNodeOutputMessage
+                                )
+                                and track_id
+                                in frame_n_outputs[cam_id].skeleton_observations
+                            }
+                            performer_camera_observations[performer_id] = observations
+                            points: dict[str, np.ndarray] = {}
+                            errors: dict[str, float] = {}
+                            if observations:
+                                _merge_angulation(
+                                    angulation=calibration.try_angulate(
+                                        frame_number=last_received_frame,
+                                        frame_observations_by_camera=observations,
+                                        max_reprojection_error_px=filter_config.max_reprojection_error_px,
+                                        triangulation_config=aggregator_config.triangulation_config,
+                                    ),
+                                    into_points=points,
+                                    into_errors=errors,
+                                )
+                            if points:
+                                performer_skeletons[performer_id] = points
+
                     # Triangulate mediapipe observations
                     skeleton_observations_by_camera = {
                         cam_id: output.skeleton_observation
                         for cam_id, output in frame_n_outputs.items()
                         if isinstance(output, CameraNodeOutputMessage)
-                           and output.skeleton_observation is not None
+                        and output.skeleton_observation is not None
                     }
                     if skeleton_observations_by_camera:
                         t0 = time.perf_counter() if timer is not None else 0.0
@@ -612,14 +733,17 @@ class RealtimeAggregatorNode(AggregatorNode):
                             into_errors=raw_errors_px,
                         )
                         if timer is not None:
-                            timer.record("skeleton_triangulation", (time.perf_counter() - t0) * 1e3)
+                            timer.record(
+                                "skeleton_triangulation",
+                                (time.perf_counter() - t0) * 1e3,
+                            )
 
                     # Triangulate charuco observations
                     charuco_observations_by_camera = {
                         cam_id: output.charuco_observation
                         for cam_id, output in frame_n_outputs.items()
                         if isinstance(output, CameraNodeOutputMessage)
-                           and output.charuco_observation is not None
+                        and output.charuco_observation is not None
                     }
                     if charuco_observations_by_camera:
                         t0 = time.perf_counter() if timer is not None else 0.0
@@ -634,9 +758,16 @@ class RealtimeAggregatorNode(AggregatorNode):
                             into_errors=raw_errors_px,
                         )
                         if timer is not None:
-                            timer.record("charuco_triangulation", (time.perf_counter() - t0) * 1e3)
+                            timer.record(
+                                "charuco_triangulation",
+                                (time.perf_counter() - t0) * 1e3,
+                            )
 
-                    if not raw_keypoints and skeleton_observations_by_camera and not _empty_3d_logged:
+                    if (
+                        not raw_keypoints
+                        and skeleton_observations_by_camera
+                        and not _empty_3d_logged
+                    ):
                         _empty_3d_logged = True
                         logger.warning(
                             f"RealtimeAggregationNode [{camera_group_id}]: "
@@ -662,7 +793,9 @@ class RealtimeAggregatorNode(AggregatorNode):
                             if name not in filter_result.predicted_names
                         }
                         if timer is not None:
-                            timer.record("keypoint_filter", (time.perf_counter() - t0) * 1e3)
+                            timer.record(
+                                "keypoint_filter", (time.perf_counter() - t0) * 1e3
+                            )
 
                     # Velocity gate: reject teleportation spikes
                     if aggregator_config.filter_enabled:
@@ -676,13 +809,12 @@ class RealtimeAggregatorNode(AggregatorNode):
                                 if not np.any(np.isnan(coords)):
                                     filtered_keypoints[point_name] = coords
                             if timer is not None:
-                                timer.record("velocity_gate", (time.perf_counter() - t0) * 1e3)
+                                timer.record(
+                                    "velocity_gate", (time.perf_counter() - t0) * 1e3
+                                )
 
                     # ---- Rigid-body skeleton correction ----
-                    if (
-                        skeleton_rigidifier is not None
-                        and filtered_keypoints
-                    ):
+                    if skeleton_rigidifier is not None and filtered_keypoints:
                         t0 = time.perf_counter() if timer is not None else 0.0
                         rigid_result = skeleton_rigidifier.rigidify_frame(
                             filtered_keypoints,
@@ -690,7 +822,9 @@ class RealtimeAggregatorNode(AggregatorNode):
                             t=frame_time,
                         )
                         if timer is not None:
-                            timer.record("skeleton_fitting", (time.perf_counter() - t0) * 1e3)
+                            timer.record(
+                                "skeleton_fitting", (time.perf_counter() - t0) * 1e3
+                            )
 
                     # ---- Center of mass ----
                     # Prefer the rigidified skeleton (matches posthoc, which
@@ -716,7 +850,9 @@ class RealtimeAggregatorNode(AggregatorNode):
                                 biomechanics=biomechanics,
                             )
                         if timer is not None:
-                            timer.record("center_of_mass", (time.perf_counter() - t0) * 1e3)
+                            timer.record(
+                                "center_of_mass", (time.perf_counter() - t0) * 1e3
+                            )
 
                         # ---- XCoM (extrapolated center of mass) ----
                         # Inverted pendulum model requires CoM above ground plane.
@@ -756,7 +892,10 @@ class RealtimeAggregatorNode(AggregatorNode):
 
                 # Convert to Point3d once at the end for the output message
                 if timer is not None:
-                    timer.record("full_frame_processing", (time.perf_counter() - t_frame_start) * 1e3)
+                    timer.record(
+                        "full_frame_processing",
+                        (time.perf_counter() - t_frame_start) * 1e3,
+                    )
                     now = time.perf_counter()
                     if recorded_first_frame:
                         timer.record("loop_time", (now - previous_loop_tik) * 1e3)
@@ -773,13 +912,18 @@ class RealtimeAggregatorNode(AggregatorNode):
                 # anthropometric proportions. Per-frame cost is ~8 distances.
                 if body_proportion_monitor is not None:
                     body_proportion_monitor.update(filtered_keypoints)
-                    if body_proportion_monitor.n_seen % DEFAULT_DIAGNOSTIC_INTERVAL == 0:
+                    if (
+                        body_proportion_monitor.n_seen % DEFAULT_DIAGNOSTIC_INTERVAL
+                        == 0
+                    ):
                         proportion_report = body_proportion_monitor.report()
                         if (
                             len(proportion_report.assessable())
                             >= proportion_report.thresholds.min_assessable_segments
                         ):
-                            drift = proportion_report.human_shape_violations(check_rigidity=False)
+                            drift = proportion_report.human_shape_violations(
+                                check_rigidity=False
+                            )
                             # if drift:
                             #     logger.warning(
                             #         f"RealtimeAggregationNode [{camera_group_id}] "
@@ -813,6 +957,22 @@ class RealtimeAggregatorNode(AggregatorNode):
                             if rigid_result is not None
                             else None
                         ),
+                        performer_skeletons={
+                            **performer_skeletons,
+                            **(
+                                {
+                                    "performer-1": {
+                                        **rigid_result.body_positions,
+                                        **rigid_result.left_hand_positions,
+                                        **rigid_result.right_hand_positions,
+                                    }
+                                }
+                                if rigid_result is not None
+                                and pipeline_config.camera_node_config.multi_person_enabled
+                                else {}
+                            ),
+                        },
+                        performer_camera_observations=performer_camera_observations,
                         body_kinematics=body_kinematics,
                     ),
                 )

--- a/freemocap/core/pipeline/realtime/realtime_pipeline.py
+++ b/freemocap/core/pipeline/realtime/realtime_pipeline.py
@@ -486,6 +486,7 @@ class RealtimePipeline:
                     point_names=list(aggregation_output.keypoints_arrays.keys()),
                     keypoints_arrays=aggregation_output.keypoints_arrays,
                     skeleton_arrays=aggregation_output.keypoints_arrays,
+                    performer_skeleton_arrays=aggregation_output.performer_skeletons,
                     embed_keypoint_names=True,
                 )
             else:
@@ -502,6 +503,7 @@ class RealtimePipeline:
                     point_names=RTMPOSE_WHOLEBODY_DEFINITION.tracked_points,
                     keypoints_arrays=aggregation_output.keypoints_arrays,
                     skeleton_arrays=rtm_skeleton,
+                    performer_skeleton_arrays=aggregation_output.performer_skeletons,
                 )
             return FrontendImagePacket(
                 images_bytearray=frames_bytearray,

--- a/freemocap/core/pipeline/realtime/realtime_skeleton_inference_node.py
+++ b/freemocap/core/pipeline/realtime/realtime_skeleton_inference_node.py
@@ -28,6 +28,7 @@ Backpressure:
   messages are dropped rather than queued. If inference falls behind the camera
   group's frame rate, we lose frames instead of accumulating lag.
 """
+
 import gc
 import logging
 import time
@@ -55,11 +56,18 @@ from skellycam.utilities.wait_functions import wait_1ms
 from skellytracker.core.data_primitives.observation import Observation  # noqa: TC002
 from skellytracker.core.tracker.tracker import Tracker
 from skellytracker.core.tracker.tracker_state import TrackerState  # noqa: TC002
+from skellytracker.core.tracker.multi_person_tracker import MultiPersonTracker
+from skellytracker.core.tracker.person_track import PersonTrackState  # noqa: TC002
+from skellytracker.core.temporal_processing.multi_person_config import (
+    MultiPersonTrackingConfig,
+)
 from skellytracker.core.sessions.onnx_session import OnnxSession
 
 from freemocap.core.pipeline.abcs.pipeline_ipc import PipelineIPC
 from freemocap.core.pipeline.abcs.source_node_abc import SourceNode
-from freemocap.core.pipeline.realtime.realtime_pipeline_config import RealtimePipelineConfig
+from freemocap.core.pipeline.realtime.realtime_pipeline_config import (
+    RealtimePipelineConfig,
+)
 from freemocap.core.pipeline.pipeline_stage_timer import PipelineStageTimer
 from freemocap.core.types.type_overloads import TopicPublicationQueue
 from freemocap.pubsub.pubsub_manager import PubSubTopicManager
@@ -82,15 +90,15 @@ class RealtimeSkeletonInferenceNode(SourceNode):
 
     @classmethod
     def create(
-            cls,
-            *,
-            camera_group_id: CameraGroupIdString,
-            camera_ids: list[CameraIdString],
-            worker_registry: WorkerRegistry,
-            camera_group_shm_dto: CameraGroupSharedMemoryDTO,
-            config: RealtimePipelineConfig,
-            ipc: PipelineIPC,
-            pubsub: PubSubTopicManager,
+        cls,
+        *,
+        camera_group_id: CameraGroupIdString,
+        camera_ids: list[CameraIdString],
+        worker_registry: WorkerRegistry,
+        camera_group_shm_dto: CameraGroupSharedMemoryDTO,
+        config: RealtimePipelineConfig,
+        ipc: PipelineIPC,
+        pubsub: PubSubTopicManager,
     ) -> "RealtimeSkeletonInferenceNode":
         shutdown_self_flag, worker = cls._create_worker(
             target=cls._run,
@@ -103,9 +111,13 @@ class RealtimeSkeletonInferenceNode(SourceNode):
                 pipeline_config=config,
                 ipc=ipc,
                 camera_group_shm_dto=camera_group_shm_dto,
-                process_frame_number_sub=pubsub.get_subscription(ProcessFrameNumberTopic),
+                process_frame_number_sub=pubsub.get_subscription(
+                    ProcessFrameNumberTopic
+                ),
                 pipeline_config_sub=pubsub.get_subscription(PipelineConfigUpdateTopic),
-                skeleton_result_pub=pubsub.get_publication_queue(SkeletonInferenceResultTopic),
+                skeleton_result_pub=pubsub.get_publication_queue(
+                    SkeletonInferenceResultTopic
+                ),
                 timing_pub=pubsub.get_publication_queue(PipelineTimingTopic),
             ),
         )
@@ -116,17 +128,17 @@ class RealtimeSkeletonInferenceNode(SourceNode):
 
     @staticmethod
     def _run(
-            *,
-            camera_group_id: CameraGroupIdString,
-            camera_ids: list[CameraIdString],
-            pipeline_config: RealtimePipelineConfig,
-            ipc: PipelineIPC,
-            shutdown_self_flag: Synchronized,
-            camera_group_shm_dto: CameraGroupSharedMemoryDTO,
-            process_frame_number_sub: TopicSubscriptionQueue,
-            pipeline_config_sub: TopicSubscriptionQueue,
-            skeleton_result_pub: TopicPublicationQueue,
-            timing_pub: TopicPublicationQueue,
+        *,
+        camera_group_id: CameraGroupIdString,
+        camera_ids: list[CameraIdString],
+        pipeline_config: RealtimePipelineConfig,
+        ipc: PipelineIPC,
+        shutdown_self_flag: Synchronized,
+        camera_group_shm_dto: CameraGroupSharedMemoryDTO,
+        process_frame_number_sub: TopicSubscriptionQueue,
+        pipeline_config_sub: TopicSubscriptionQueue,
+        skeleton_result_pub: TopicPublicationQueue,
+        timing_pub: TopicPublicationQueue,
     ) -> None:
         logger.debug(f"RealtimeSkeletonInferenceNode [{camera_group_id}] initializing")
 
@@ -142,7 +154,9 @@ class RealtimeSkeletonInferenceNode(SourceNode):
             for camera_id in camera_ids
         }
 
-        tracker, session = _build_session_and_tracker(pipeline_config, num_cameras=len(camera_ids))
+        tracker, session = _build_session_and_tracker(
+            pipeline_config, num_cameras=len(camera_ids)
+        )
         if tracker is None:
             logger.error(
                 f"RealtimeSkeletonInferenceNode [{camera_group_id}] could not "
@@ -154,7 +168,8 @@ class RealtimeSkeletonInferenceNode(SourceNode):
         log_pipeline_times = pipeline_config.log_pipeline_times
         timer = (
             PipelineStageTimer(name=f"SkeletonInferenceNode-{camera_group_id}")
-            if log_pipeline_times else None
+            if log_pipeline_times
+            else None
         )
         _MAX_SESSION_RESTARTS = 3
         session_restart_count = 0
@@ -164,6 +179,14 @@ class RealtimeSkeletonInferenceNode(SourceNode):
         }
         # Per-camera temporal state; empty dict means first frame auto-inits.
         tracker_states: dict[CameraIdString, TrackerState] = {}
+        multi_trackers: dict[CameraIdString, MultiPersonTracker] = {}
+        multi_track_states: dict[CameraIdString, dict[int, PersonTrackState]] = {}
+        if pipeline_config.camera_node_config.multi_person_enabled:
+            multi_trackers = _build_multi_person_trackers(
+                pipeline_config=pipeline_config,
+                camera_ids=camera_ids,
+                session=session,
+            )
 
         try:
             logger.debug(
@@ -175,7 +198,9 @@ class RealtimeSkeletonInferenceNode(SourceNode):
                 # ---- Handle config updates ----
                 while True:
                     try:
-                        msg: PipelineConfigUpdateMessage = pipeline_config_sub.get_nowait()
+                        msg: PipelineConfigUpdateMessage = (
+                            pipeline_config_sub.get_nowait()
+                        )
                     except Empty:
                         break
                     pipeline_config = msg.pipeline_config
@@ -232,13 +257,37 @@ class RealtimeSkeletonInferenceNode(SourceNode):
                 # ---- Batched skeleton inference ----
                 t_inf = time.perf_counter() if timer is not None else 0.0
                 images_dict = {
-                    cam_id: img
-                    for cam_id, img in zip(ordered_camera_ids, images)
+                    cam_id: img for cam_id, img in zip(ordered_camera_ids, images)
                 }
                 try:
-                    observations, tracker_states = tracker.process_batch(
-                        images_dict, requested_frame_number, tracker_states
-                    )
+                    per_camera_people: dict[CameraIdString, dict[str, Observation]] = {}
+                    if pipeline_config.camera_node_config.multi_person_enabled:
+                        observations = {}
+                        for camera_id, image in images_dict.items():
+                            observation, states = multi_trackers[
+                                camera_id
+                            ].process_image(
+                                image=image,
+                                frame_number=requested_frame_number,
+                                tracks=multi_track_states.get(camera_id, {}),
+                            )
+                            multi_track_states[camera_id] = states
+                            people = {
+                                str(track_id): person
+                                for track_id, person in observation.people.items()
+                            }
+                            per_camera_people[camera_id] = people
+                            observations[camera_id] = next(iter(people.values()), None)
+                    else:
+                        observations, tracker_states = tracker.process_batch(
+                            images_dict, requested_frame_number, tracker_states
+                        )
+                        per_camera_people = {
+                            camera_id: (
+                                {"0": observation} if observation is not None else {}
+                            )
+                            for camera_id, observation in observations.items()
+                        }
                 except Exception as mem_err:
                     if not (
                         isinstance(mem_err, MemoryError)
@@ -259,8 +308,12 @@ class RealtimeSkeletonInferenceNode(SourceNode):
                         ipc.kill_everything()
                         return
                     tracker.close()
+                    for multi_tracker in multi_trackers.values():
+                        multi_tracker.close()
                     gc.collect()
-                    tracker, session = _build_session_and_tracker(pipeline_config, num_cameras=len(camera_ids))
+                    tracker, session = _build_session_and_tracker(
+                        pipeline_config, num_cameras=len(camera_ids)
+                    )
                     if tracker is None:
                         logger.error(
                             f"RealtimeSkeletonInferenceNode [{camera_group_id}] failed to rebuild "
@@ -269,6 +322,16 @@ class RealtimeSkeletonInferenceNode(SourceNode):
                         ipc.kill_everything()
                         return
                     tracker_states = {}
+                    multi_track_states = {}
+                    multi_trackers = (
+                        _build_multi_person_trackers(
+                            pipeline_config=pipeline_config,
+                            camera_ids=camera_ids,
+                            session=session,
+                        )
+                        if pipeline_config.camera_node_config.multi_person_enabled
+                        else {}
+                    )
                     session_restart_count += 1
                     logger.info(
                         f"RealtimeSkeletonInferenceNode [{camera_group_id}] tracker rebuilt "
@@ -285,6 +348,9 @@ class RealtimeSkeletonInferenceNode(SourceNode):
                 conf_threshold = pipeline_config.camera_node_config.confidence_threshold
                 per_camera_skeleton: dict[CameraIdString, Observation | None] = {}
                 for camera_id, obs in observations.items():
+                    if obs is None:
+                        per_camera_skeleton[camera_id] = None
+                        continue
                     body_stage = obs.stages.get("body")
                     if body_stage is not None and body_stage.keypoints is not None:
                         kpts = body_stage.keypoints
@@ -292,6 +358,15 @@ class RealtimeSkeletonInferenceNode(SourceNode):
                         if low_conf.any():
                             kpts.xyz[low_conf, :2] = np.nan
                     per_camera_skeleton[camera_id] = obs
+
+                for people in per_camera_people.values():
+                    for obs in people.values():
+                        body_stage = obs.stages.get("body")
+                        if body_stage is not None and body_stage.keypoints is not None:
+                            kpts = body_stage.keypoints
+                            low_conf = kpts.visibility < conf_threshold
+                            if low_conf.any():
+                                kpts.xyz[low_conf, :2] = np.nan
 
                 # Cameras whose frame we couldn't read get None.
                 for camera_id in camera_ids:
@@ -301,6 +376,7 @@ class RealtimeSkeletonInferenceNode(SourceNode):
                     SkeletonInferenceResultMessage(
                         frame_number=requested_frame_number,
                         per_camera_skeleton=per_camera_skeleton,
+                        per_camera_people=per_camera_people,
                     ),
                 )
                 if timer is not None:
@@ -319,6 +395,8 @@ class RealtimeSkeletonInferenceNode(SourceNode):
         finally:
             if tracker is not None:
                 tracker.close()
+            for multi_tracker in multi_trackers.values():
+                multi_tracker.close()
             logger.debug(f"RealtimeSkeletonInferenceNode [{camera_group_id}] exiting")
 
 
@@ -339,6 +417,7 @@ def _build_session_and_tracker(
 
     if camera_node_config.detector_type == "mediapipe":
         from freemocap.core.tracking.tracker_factory import build_mediapipe_tracker
+
         try:
             tracker, session = build_mediapipe_tracker(
                 model_complexity=camera_node_config.mediapipe_model_complexity,
@@ -384,12 +463,33 @@ def _build_session_and_tracker(
         return None, None
 
 
+def _build_multi_person_trackers(
+    *,
+    pipeline_config: RealtimePipelineConfig,
+    camera_ids: list[CameraIdString],
+    session: object,
+) -> dict[CameraIdString, MultiPersonTracker]:
+    config = pipeline_config.camera_node_config.skeleton_tracker_config
+    if config is None:
+        raise RuntimeError("Multi-person tracking requires a skeleton_tracker_config.")
+    max_persons = pipeline_config.camera_node_config.max_persons
+    return {
+        camera_id: MultiPersonTracker.create(
+            config=config,
+            sessions={"onnx": session},
+            multi_person_config=MultiPersonTrackingConfig(max_persons=max_persons),
+            owns_sessions=False,
+        )
+        for camera_id in camera_ids
+    }
+
+
 def _read_frames(
-        *,
-        camera_ids: list[CameraIdString],
-        camera_shms: dict[CameraIdString, CameraSharedMemoryRingBuffer],
-        frame_recarrays: dict[CameraIdString, np.recarray | None],
-        requested_frame_number: int,
+    *,
+    camera_ids: list[CameraIdString],
+    camera_shms: dict[CameraIdString, CameraSharedMemoryRingBuffer],
+    frame_recarrays: dict[CameraIdString, np.recarray | None],
+    requested_frame_number: int,
 ) -> tuple[list[NDArray[np.uint8]], list[CameraIdString]]:
     """Read frame `requested_frame_number` from each camera's ring buffer."""
     images: list[NDArray[np.uint8]] = []

--- a/freemocap/core/tracking/multi_person_association.py
+++ b/freemocap/core/tracking/multi_person_association.py
@@ -5,13 +5,16 @@ module associates those stable camera tracks across views using features that
 survive a crossing better than bounding boxes alone: pelvis position, relative
 bone lengths, and a coarse colour histogram.
 """
+
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import permutations
 
 import numpy as np
 from numpy.typing import NDArray
+
+from skellytracker.core.data_primitives.observation import Observation  # noqa: TC002
 
 
 @dataclass(frozen=True)
@@ -22,10 +25,40 @@ class PersonDescriptor:
     appearance_histogram: NDArray[np.float64]
 
 
-def appearance_histogram(image: NDArray[np.uint8], bbox: tuple[int, int, int, int]) -> NDArray[np.float64]:
+def observation_descriptor(
+    detection_id: str, observation: Observation
+) -> PersonDescriptor:
+    keypoints = observation.to_keypoints()
+    height, width = observation.image_size
+    scale = np.array(
+        [max(width, 1), max(height, 1), max(width, height, 1)], dtype=np.float64
+    )
+    points = {
+        name.rsplit(".", 1)[-1]: coords / scale
+        for name, coords in zip(keypoints.names, keypoints.xyz, strict=True)
+        if np.all(np.isfinite(coords))
+    }
+    left_hip = points.get("left_hip")
+    right_hip = points.get("right_hip")
+    pelvis = (
+        (left_hip + right_hip) / 2.0
+        if left_hip is not None and right_hip is not None
+        else np.zeros(3, dtype=np.float64)
+    )
+    return PersonDescriptor(
+        detection_id=detection_id,
+        pelvis=pelvis,
+        bone_signature=bone_length_signature(points),
+        appearance_histogram=np.zeros(512, dtype=np.float64),
+    )
+
+
+def appearance_histogram(
+    image: NDArray[np.uint8], bbox: tuple[int, int, int, int]
+) -> NDArray[np.float64]:
     """Return a normalized 8x8x8 RGB histogram for an in-frame person crop."""
     x1, y1, x2, y2 = bbox
-    crop = image[max(0, y1):max(0, y2), max(0, x1):max(0, x2)]
+    crop = image[max(0, y1) : max(0, y2), max(0, x1) : max(0, x2)]
     if crop.size == 0:
         return np.zeros(512, dtype=np.float64)
     histogram, _ = np.histogramdd(
@@ -47,7 +80,9 @@ def bone_length_signature(
         ("right_hip", "right_ankle"),
     )
     lengths = [
-        float(np.linalg.norm(points[a] - points[b])) if a in points and b in points else np.nan
+        float(np.linalg.norm(points[a] - points[b]))
+        if a in points and b in points
+        else np.nan
         for a, b in pairs
     ]
     signature = np.asarray(lengths, dtype=np.float64)
@@ -57,13 +92,17 @@ def bone_length_signature(
 
 
 def descriptor_cost(reference: PersonDescriptor, candidate: PersonDescriptor) -> float:
-    pelvis_cost = min(float(np.linalg.norm(reference.pelvis - candidate.pelvis)) / 2_000.0, 1.0)
+    pelvis_cost = min(
+        float(np.linalg.norm(reference.pelvis - candidate.pelvis)) / 2_000.0, 1.0
+    )
     signature_cost = min(
         float(np.linalg.norm(reference.bone_signature - candidate.bone_signature))
         / max(np.sqrt(reference.bone_signature.size), 1.0),
         1.0,
     )
-    overlap = float(np.sqrt(reference.appearance_histogram * candidate.appearance_histogram).sum())
+    overlap = float(
+        np.sqrt(reference.appearance_histogram * candidate.appearance_histogram).sum()
+    )
     appearance_cost = 1.0 - min(max(overlap, 0.0), 1.0)
     return 0.45 * pelvis_cost + 0.35 * signature_cost + 0.20 * appearance_cost
 
@@ -86,20 +125,106 @@ def associate_two_person_views(
     if not refs or not detections:
         return {}
     cost = np.asarray(
-        [[descriptor_cost(reference, candidate) for candidate in detections] for reference in refs]
+        [
+            [descriptor_cost(reference, candidate) for candidate in detections]
+            for reference in refs
+        ]
     )
     assignments = []
-    for candidate_order in permutations(range(len(detections)), min(len(refs), len(detections))):
+    for candidate_order in permutations(
+        range(len(detections)), min(len(refs), len(detections))
+    ):
         pairs = list(zip(range(len(candidate_order)), candidate_order, strict=False))
-        assignments.append((sum(float(cost[row, column]) for row, column in pairs), pairs))
+        assignments.append(
+            (sum(float(cost[row, column]) for row, column in pairs), pairs)
+        )
     _, best = min(assignments, key=lambda item: item[0])
     result: dict[str, str] = {}
     for row, column in best:
         alternatives = np.delete(cost[row], column)
-        ambiguous = alternatives.size and float(alternatives.min() - cost[row, column]) < ambiguity_margin
+        ambiguous = (
+            alternatives.size
+            and float(alternatives.min() - cost[row, column]) < ambiguity_margin
+        )
         if not ambiguous and cost[row, column] <= max_cost:
             result[refs[row].detection_id] = detections[column].detection_id
     return result
+
+
+@dataclass
+class CrossCameraAssociator:
+    """Keep local camera track ids attached to two stable performer ids."""
+
+    max_cost: float = 0.75
+    ambiguity_margin: float = 0.06
+    _track_assignments: dict[tuple[str, str], str] = field(default_factory=dict)
+    _profiles: dict[str, PersonDescriptor] = field(default_factory=dict)
+
+    def assign(
+        self,
+        per_camera: dict[str, list[PersonDescriptor]],
+    ) -> dict[str, dict[str, str]]:
+        active_cameras = [
+            camera_id for camera_id, values in sorted(per_camera.items()) if values
+        ]
+        if not active_cameras:
+            return {}
+
+        primary_id = active_cameras[0]
+        primary = per_camera[primary_id][:2]
+        used: set[str] = set()
+        grouped: dict[str, dict[str, str]] = {}
+
+        for descriptor in primary:
+            key = (primary_id, descriptor.detection_id)
+            performer_id = self._track_assignments.get(key)
+            if performer_id in used:
+                performer_id = None
+            if performer_id is None:
+                available = [
+                    value
+                    for value in ("performer-1", "performer-2")
+                    if value not in used
+                ]
+                ranked = sorted(
+                    (
+                        (descriptor_cost(self._profiles[value], descriptor), value)
+                        for value in available
+                        if value in self._profiles
+                    ),
+                    key=lambda item: item[0],
+                )
+                performer_id = (
+                    ranked[0][1]
+                    if ranked and ranked[0][0] <= self.max_cost
+                    else available[0]
+                )
+            self._track_assignments[key] = performer_id
+            self._profiles[performer_id] = descriptor
+            used.add(performer_id)
+            grouped.setdefault(performer_id, {})[primary_id] = descriptor.detection_id
+
+        references = [
+            PersonDescriptor(
+                detection_id=performer_id,
+                pelvis=self._profiles[performer_id].pelvis,
+                bone_signature=self._profiles[performer_id].bone_signature,
+                appearance_histogram=self._profiles[performer_id].appearance_histogram,
+            )
+            for performer_id in sorted(grouped)
+        ]
+        for camera_id in active_cameras[1:]:
+            candidates = per_camera[camera_id][:2]
+            mapped = associate_two_person_views(
+                references,
+                candidates,
+                max_cost=self.max_cost,
+                ambiguity_margin=self.ambiguity_margin,
+            )
+            for performer_id, detection_id in mapped.items():
+                grouped.setdefault(performer_id, {})[camera_id] = detection_id
+                self._track_assignments[(camera_id, detection_id)] = performer_id
+        return grouped
 
 
 def performer_parquet_rows(
@@ -113,12 +238,14 @@ def performer_parquet_rows(
             xyz = np.asarray(point, dtype=np.float64).reshape(-1)
             if xyz.size < 3:
                 continue
-            rows.append({
-                "frame_number": frame_number,
-                "performer_id": performer_id,
-                "point_name": point_name,
-                "x": float(xyz[0]),
-                "y": float(xyz[1]),
-                "z": float(xyz[2]),
-            })
+            rows.append(
+                {
+                    "frame_number": frame_number,
+                    "performer_id": performer_id,
+                    "point_name": point_name,
+                    "x": float(xyz[0]),
+                    "y": float(xyz[1]),
+                    "z": float(xyz[2]),
+                }
+            )
     return rows

--- a/freemocap/core/tracking/multi_person_association.py
+++ b/freemocap/core/tracking/multi_person_association.py
@@ -1,0 +1,124 @@
+"""Small, dependency-light identity features for two-person camera association.
+
+The temporal tracker in SkellyTracker owns per-camera track continuity. This
+module associates those stable camera tracks across views using features that
+survive a crossing better than bounding boxes alone: pelvis position, relative
+bone lengths, and a coarse colour histogram.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import permutations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True)
+class PersonDescriptor:
+    detection_id: str
+    pelvis: NDArray[np.float64]
+    bone_signature: NDArray[np.float64]
+    appearance_histogram: NDArray[np.float64]
+
+
+def appearance_histogram(image: NDArray[np.uint8], bbox: tuple[int, int, int, int]) -> NDArray[np.float64]:
+    """Return a normalized 8x8x8 RGB histogram for an in-frame person crop."""
+    x1, y1, x2, y2 = bbox
+    crop = image[max(0, y1):max(0, y2), max(0, x1):max(0, x2)]
+    if crop.size == 0:
+        return np.zeros(512, dtype=np.float64)
+    histogram, _ = np.histogramdd(
+        crop.reshape(-1, 3), bins=(8, 8, 8), range=((0, 256), (0, 256), (0, 256))
+    )
+    flat = histogram.reshape(-1).astype(np.float64)
+    return flat / max(float(flat.sum()), 1.0)
+
+
+def bone_length_signature(
+    points: dict[str, NDArray[np.float64]],
+) -> NDArray[np.float64]:
+    pairs = (
+        ("left_shoulder", "right_shoulder"),
+        ("left_hip", "right_hip"),
+        ("left_shoulder", "left_wrist"),
+        ("right_shoulder", "right_wrist"),
+        ("left_hip", "left_ankle"),
+        ("right_hip", "right_ankle"),
+    )
+    lengths = [
+        float(np.linalg.norm(points[a] - points[b])) if a in points and b in points else np.nan
+        for a, b in pairs
+    ]
+    signature = np.asarray(lengths, dtype=np.float64)
+    finite = signature[np.isfinite(signature)]
+    scale = float(np.median(finite)) if finite.size else 1.0
+    return np.nan_to_num(signature / max(scale, 1e-6), nan=0.0)
+
+
+def descriptor_cost(reference: PersonDescriptor, candidate: PersonDescriptor) -> float:
+    pelvis_cost = min(float(np.linalg.norm(reference.pelvis - candidate.pelvis)) / 2_000.0, 1.0)
+    signature_cost = min(
+        float(np.linalg.norm(reference.bone_signature - candidate.bone_signature))
+        / max(np.sqrt(reference.bone_signature.size), 1.0),
+        1.0,
+    )
+    overlap = float(np.sqrt(reference.appearance_histogram * candidate.appearance_histogram).sum())
+    appearance_cost = 1.0 - min(max(overlap, 0.0), 1.0)
+    return 0.45 * pelvis_cost + 0.35 * signature_cost + 0.20 * appearance_cost
+
+
+def associate_two_person_views(
+    references: list[PersonDescriptor],
+    candidates: list[PersonDescriptor],
+    *,
+    max_cost: float = 0.75,
+    ambiguity_margin: float = 0.06,
+) -> dict[str, str]:
+    """Map reference ids to candidate ids, holding ambiguous matches.
+
+    The exhaustive assignment is intentional: the milestone is capped at two
+    people, making this deterministic equivalent of Hungarian assignment easy
+    to audit while avoiding another runtime dependency in the realtime path.
+    """
+    refs = references[:2]
+    detections = candidates[:2]
+    if not refs or not detections:
+        return {}
+    cost = np.asarray(
+        [[descriptor_cost(reference, candidate) for candidate in detections] for reference in refs]
+    )
+    assignments = []
+    for candidate_order in permutations(range(len(detections)), min(len(refs), len(detections))):
+        pairs = list(zip(range(len(candidate_order)), candidate_order, strict=False))
+        assignments.append((sum(float(cost[row, column]) for row, column in pairs), pairs))
+    _, best = min(assignments, key=lambda item: item[0])
+    result: dict[str, str] = {}
+    for row, column in best:
+        alternatives = np.delete(cost[row], column)
+        ambiguous = alternatives.size and float(alternatives.min() - cost[row, column]) < ambiguity_margin
+        if not ambiguous and cost[row, column] <= max_cost:
+            result[refs[row].detection_id] = detections[column].detection_id
+    return result
+
+
+def performer_parquet_rows(
+    frame_number: int,
+    performer_points: dict[str, dict[str, NDArray[np.float64]]],
+) -> list[dict[str, float | int | str]]:
+    """Long-form rows with performer_id for Parquet writers."""
+    rows: list[dict[str, float | int | str]] = []
+    for performer_id, points in performer_points.items():
+        for point_name, point in points.items():
+            xyz = np.asarray(point, dtype=np.float64).reshape(-1)
+            if xyz.size < 3:
+                continue
+            rows.append({
+                "frame_number": frame_number,
+                "performer_id": performer_id,
+                "point_name": point_name,
+                "x": float(xyz[0]),
+                "y": float(xyz[1]),
+                "z": float(xyz[2]),
+            })
+    return rows

--- a/freemocap/core/viz/frontend_keypoints_serializer.py
+++ b/freemocap/core/viz/frontend_keypoints_serializer.py
@@ -118,7 +118,8 @@ def build_keypoints_payload(
         tracker_id: str,
         point_names: tuple[str, ...] | list[str],
         keypoints_arrays: dict[str, np.ndarray],
-        skeleton_arrays: dict[str, np.ndarray] | None = None,
+    skeleton_arrays: dict[str, np.ndarray] | None = None,
+    performer_skeleton_arrays: dict[str, dict[str, np.ndarray]] | None = None,
         embed_keypoint_names: bool = False,
 ) -> bytearray:
     """Serialize the per-frame 3D keypoints + skeleton into the binary wire format.
@@ -172,6 +173,24 @@ def build_keypoints_payload(
                 tracker_id="skeleton3d",
                 point_names=skeleton_names,
                 sparse_arrays=skeleton_arrays,
+                embed_names=True,
+            )
+        )
+
+    # Multi-person extension: each performer uses the existing self-describing
+    # SKELETON_3D block layout. The stable performer id rides in camera_id,
+    # which older readers already know how to skip, so single-person payloads
+    # and the block header remain byte-for-byte compatible.
+    for performer_id, performer_skeleton in (performer_skeleton_arrays or {}).items():
+        if not performer_skeleton:
+            continue
+        blocks.append(
+            _build_block(
+                kind=BlockKind.SKELETON_3D,
+                tracker_id="skeleton3d",
+                camera_id=performer_id,
+                point_names=list(performer_skeleton.keys()),
+                sparse_arrays=performer_skeleton,
                 embed_names=True,
             )
         )

--- a/freemocap/core/viz/frontend_payload.py
+++ b/freemocap/core/viz/frontend_payload.py
@@ -4,11 +4,19 @@ import msgspec
 import numpy as np
 from freemocap.core.viz.image_overlay.skeleton_overlay_data import SkeletonOverlayData
 from skellycam.core.camera_group.camera_group import CameraGroup
-from skellycam.core.types.type_overloads import CameraIdString, CameraGroupIdString, MultiframeTimestampFloat
+from skellycam.core.types.type_overloads import (
+    CameraIdString,
+    CameraGroupIdString,
+    MultiframeTimestampFloat,
+)
 from skellyforge.data_models.trajectory_3d import Point3d
 
 from freemocap.core.kinematics.body_kinematics_state import BodyKinematicsState
-from freemocap.core.types.type_overloads import TrackedPointNameString, PipelineIdString, FrameNumberInt
+from freemocap.core.types.type_overloads import (
+    TrackedPointNameString,
+    PipelineIdString,
+    FrameNumberInt,
+)
 from freemocap.core.viz.image_overlay.charuco_overlay_data import CharucoOverlayData
 from freemocap.pubsub.pubsub_topics import AggregationNodeOutputMessage
 
@@ -32,14 +40,17 @@ class FrontendPayload(msgspec.Struct):
     pipeline_id: PipelineIdString | None = None
     charuco_overlays: dict[CameraIdString, CharucoOverlayData] | None = None
     skeleton_overlays: dict[CameraIdString, SkeletonOverlayData] | None = None
+    multi_person_skeleton_overlays: (
+        dict[CameraIdString, dict[str, SkeletonOverlayData]] | None
+    ) = None
     center_of_mass: Point3d | None = None
     xcom: Point3d | None = None
     body_kinematics: BodyKinematicsState | None = None
 
     @classmethod
     def from_aggregation_output(
-            cls,
-            aggregation_output: AggregationNodeOutputMessage,
+        cls,
+        aggregation_output: AggregationNodeOutputMessage,
     ) -> "FrontendPayload":
         """Create frontend payload from aggregation node output."""
         com = aggregation_output.center_of_mass_result
@@ -58,10 +69,12 @@ class FrontendPayload(msgspec.Struct):
             pipeline_id=aggregation_output.pipeline_id,
             charuco_overlays=aggregation_output.charuco_overlay_data,
             skeleton_overlays=aggregation_output.skeleton_overlay_data,
+            multi_person_skeleton_overlays=aggregation_output.multi_person_skeleton_overlay_data,
             center_of_mass=com_point,
             xcom=aggregation_output.xcom,
             body_kinematics=aggregation_output.body_kinematics,
         )
+
 
 @dataclass(slots=True, frozen=True)
 class FrontendImagePacket:

--- a/freemocap/pubsub/pubsub_topics.py
+++ b/freemocap/pubsub/pubsub_topics.py
@@ -4,18 +4,25 @@ PubSub topic definitions for the pipeline system.
 Each Message + Topic pair defines a typed channel. Topics auto-register
 via __init_subclass__ so the PubSubTopicManager discovers them at startup.
 """
+
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import numpy as np
 from skellycam.core.recorders.videos.recording_info import RecordingInfo
-from skellycam.core.types.type_overloads import CameraGroupIdString, CameraIdString, MultiframeTimestampFloat
+from skellycam.core.types.type_overloads import (
+    CameraGroupIdString,
+    CameraIdString,
+    MultiframeTimestampFloat,
+)
 from skellyforge.data_models.trajectory_3d import Point3d
 from skellytracker.core.data_primitives.observation import Observation
 
 from freemocap.core.kinematics.body_kinematics_state import BodyKinematicsState
-from freemocap.core.pipeline.realtime.realtime_pipeline_config import RealtimePipelineConfig
+from freemocap.core.pipeline.realtime.realtime_pipeline_config import (
+    RealtimePipelineConfig,
+)
 from freemocap.core.tasks.mocap.center_of_mass import CenterOfMassResult
 from freemocap.core.types.type_overloads import (
     FrameNumberInt,
@@ -26,7 +33,9 @@ from freemocap.pubsub.pubsub_abcs import TopicMessageABC, create_topic
 
 if TYPE_CHECKING:
     from freemocap.core.viz.image_overlay.charuco_overlay_data import CharucoOverlayData
-    from freemocap.core.viz.image_overlay.skeleton_overlay_data import SkeletonOverlayData
+    from freemocap.core.viz.image_overlay.skeleton_overlay_data import (
+        SkeletonOverlayData,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +43,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Frame processing
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class ProcessFrameNumberMessage(TopicMessageABC):
@@ -48,6 +58,7 @@ class ProcessFrameNumberMessage(TopicMessageABC):
 # Config updates
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class PipelineConfigUpdateMessage(TopicMessageABC):
     pipeline_config: RealtimePipelineConfig = None
@@ -57,12 +68,14 @@ class PipelineConfigUpdateMessage(TopicMessageABC):
 # Realtime node outputs
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class CameraNodeOutputMessage(TopicMessageABC):
     camera_id: CameraIdString = ""
     frame_number: FrameNumberInt = 0
     charuco_observation: Observation | None = None
     skeleton_observation: Observation | None = None
+    skeleton_observations: dict[str, Observation] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.frame_number < 0:
@@ -78,10 +91,16 @@ class CameraNodeOutputMessage(TopicMessageABC):
 # CameraNodeOutputMessage (which carries charuco only in this mode) by
 # (frame_number).
 
+
 @dataclass
 class SkeletonInferenceResultMessage(TopicMessageABC):
     frame_number: FrameNumberInt = 0
-    per_camera_skeleton: dict[CameraIdString, Observation | None] = field(default_factory=dict)
+    per_camera_skeleton: dict[CameraIdString, Observation | None] = field(
+        default_factory=dict
+    )
+    per_camera_people: dict[CameraIdString, dict[str, Observation]] = field(
+        default_factory=dict
+    )
 
     def __post_init__(self) -> None:
         if self.frame_number < 0:
@@ -91,6 +110,7 @@ class SkeletonInferenceResultMessage(TopicMessageABC):
 # ---------------------------------------------------------------------------
 # Video (posthoc) node outputs
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class VideoNodeOutputMessage(TopicMessageABC):
@@ -107,18 +127,28 @@ class VideoNodeOutputMessage(TopicMessageABC):
 # Aggregation output (realtime)
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class AggregationNodeOutputMessage(TopicMessageABC):
     frame_number: FrameNumberInt = 0
     pipeline_id: PipelineIdString = ""
     pipeline_config: RealtimePipelineConfig = None
     camera_group_id: CameraGroupIdString = ""
-    camera_node_outputs: dict[CameraIdString, CameraNodeOutputMessage] = field(default_factory=dict)
-    keypoints_arrays: dict[TrackedPointNameString, np.ndarray] = field(default_factory=dict)
+    camera_node_outputs: dict[CameraIdString, CameraNodeOutputMessage] = field(
+        default_factory=dict
+    )
+    keypoints_arrays: dict[TrackedPointNameString, np.ndarray] = field(
+        default_factory=dict
+    )
     center_of_mass_result: CenterOfMassResult | None = None
     xcom: Point3d | None = None
     skeleton: dict[TrackedPointNameString, np.ndarray] | None = None
-    performer_skeletons: dict[str, dict[TrackedPointNameString, np.ndarray]] = field(default_factory=dict)
+    performer_skeletons: dict[str, dict[TrackedPointNameString, np.ndarray]] = field(
+        default_factory=dict
+    )
+    performer_camera_observations: dict[str, dict[CameraIdString, Observation]] = field(
+        default_factory=dict
+    )
     body_kinematics: BodyKinematicsState | None = None
 
     def __post_init__(self) -> None:
@@ -134,7 +164,9 @@ class AggregationNodeOutputMessage(TopicMessageABC):
 
     @property
     def charuco_overlay_data(self) -> dict:
-        from freemocap.core.viz.image_overlay.charuco_overlay_data import CharucoOverlayData
+        from freemocap.core.viz.image_overlay.charuco_overlay_data import (
+            CharucoOverlayData,
+        )
 
         overlay_data: dict[CameraIdString, CharucoOverlayData] = {}
         for camera_id, cam_output in self.camera_node_outputs.items():
@@ -147,8 +179,13 @@ class AggregationNodeOutputMessage(TopicMessageABC):
 
     @property
     def skeleton_overlay_data(self) -> dict:
-        from freemocap.core.viz.image_overlay.skeleton_overlay_data import SkeletonOverlayData
-        from freemocap.core.tracking.tracker_definitions import RTMPOSE_WHOLEBODY_DEFINITION, MEDIAPIPE_WHOLEBODY_DEFINITION
+        from freemocap.core.viz.image_overlay.skeleton_overlay_data import (
+            SkeletonOverlayData,
+        )
+        from freemocap.core.tracking.tracker_definitions import (
+            RTMPOSE_WHOLEBODY_DEFINITION,
+            MEDIAPIPE_WHOLEBODY_DEFINITION,
+        )
 
         detector_type = (
             self.pipeline_config.camera_node_config.detector_type
@@ -171,6 +208,26 @@ class AggregationNodeOutputMessage(TopicMessageABC):
                 )
         return overlay_data
 
+    @property
+    def multi_person_skeleton_overlay_data(self) -> dict:
+        from freemocap.core.viz.image_overlay.skeleton_overlay_data import (
+            SkeletonOverlayData,
+        )
+        from freemocap.core.tracking.tracker_definitions import (
+            RTMPOSE_WHOLEBODY_DEFINITION,
+        )
+
+        overlays: dict[CameraIdString, dict[str, SkeletonOverlayData]] = {}
+        for performer_id, observations in self.performer_camera_observations.items():
+            for camera_id, observation in observations.items():
+                overlays.setdefault(camera_id, {})[performer_id] = (
+                    SkeletonOverlayData.from_observation(
+                        camera_id=camera_id,
+                        observation=observation,
+                        tracker_definition_name=RTMPOSE_WHOLEBODY_DEFINITION.name,
+                    )
+                )
+        return overlays
 
     @property
     def camera_ids(self) -> list[CameraIdString]:
@@ -186,12 +243,15 @@ class AggregationNodeOutputMessage(TopicMessageABC):
 # report. Camera-node samples for the same stage collapse across camera_id
 # into ensemble statistics so adding cameras doesn't multiply log volume.
 
+
 @dataclass
 class PipelineTimingMessage(TopicMessageABC):
-    node_kind: str = ""              # "camera" | "skeleton_inference" | "aggregator"
-    node_label: str = ""             # human-readable label for log section headers
+    node_kind: str = ""  # "camera" | "skeleton_inference" | "aggregator"
+    node_label: str = ""  # human-readable label for log section headers
     camera_id: CameraIdString | None = None  # set only for camera nodes
-    samples: dict[str, list[float]] = field(default_factory=dict)  # stage -> elapsed_ms batch
+    samples: dict[str, list[float]] = field(
+        default_factory=dict
+    )  # stage -> elapsed_ms batch
 
 
 # ---------------------------------------------------------------------------
@@ -200,10 +260,12 @@ class PipelineTimingMessage(TopicMessageABC):
 # Published by the calibration HTTP endpoint when a calibration recording
 # starts or stops. The CharucoRecorderNode subscribes to toggle buffering.
 
+
 @dataclass
 class CalibrationRecordingStateMessage(TopicMessageABC):
     recording_info: RecordingInfo | None = None
     is_active: bool = False
+
 
 @dataclass
 class SkeletonFitterResetMessage(TopicMessageABC):
@@ -223,10 +285,10 @@ ProcessFrameNumberTopic = create_topic(ProcessFrameNumberMessage)
 PipelineConfigUpdateTopic = create_topic(PipelineConfigUpdateMessage)
 CameraNodeOutputTopic = create_topic(CameraNodeOutputMessage)
 SkeletonInferenceResultTopic = create_topic(SkeletonInferenceResultMessage)
-VideoNodeOutputTopic = create_topic(VideoNodeOutputMessage, queue_maxsize=0)  # unbounded: posthoc video nodes finish before aggregation node starts , #TODO - shouldnt thouh, agg node should run concurrently w/ video nodes
+VideoNodeOutputTopic = create_topic(
+    VideoNodeOutputMessage, queue_maxsize=0
+)  # unbounded: posthoc video nodes finish before aggregation node starts , #TODO - shouldnt thouh, agg node should run concurrently w/ video nodes
 AggregationNodeOutputTopic = create_topic(AggregationNodeOutputMessage)
 PipelineTimingTopic = create_topic(PipelineTimingMessage)
 CalibrationRecordingStateTopic = create_topic(CalibrationRecordingStateMessage)
 SkeletonFitterResetTopic = create_topic(SkeletonFitterResetMessage)
-
-

--- a/freemocap/pubsub/pubsub_topics.py
+++ b/freemocap/pubsub/pubsub_topics.py
@@ -118,6 +118,7 @@ class AggregationNodeOutputMessage(TopicMessageABC):
     center_of_mass_result: CenterOfMassResult | None = None
     xcom: Point3d | None = None
     skeleton: dict[TrackedPointNameString, np.ndarray] | None = None
+    performer_skeletons: dict[str, dict[TrackedPointNameString, np.ndarray]] = field(default_factory=dict)
     body_kinematics: BodyKinematicsState | None = None
 
     def __post_init__(self) -> None:

--- a/freemocap/tests/http/test_calibration_router_recording_state.py
+++ b/freemocap/tests/http/test_calibration_router_recording_state.py
@@ -15,11 +15,15 @@ def mock_app():
     """Mock FreemocapApplication with a realtime pipeline that has pubsub."""
     app = MagicMock()
     app.start_recording_all = AsyncMock()
-    app.stop_recording_all = AsyncMock(return_value=RecordingInfo(
-        recording_directory="/tmp/test",
-        recording_name="test_recording",
-    ))
-    app.create_posthoc_calibration_pipeline = AsyncMock(return_value=MagicMock(id="pipe_123"))
+    app.stop_recording_all = AsyncMock(
+        return_value=RecordingInfo(
+            recording_directory="/tmp/test",
+            recording_name="test_recording",
+        )
+    )
+    app.create_posthoc_calibration_pipeline = AsyncMock(
+        return_value=MagicMock(id="pipe_123")
+    )
 
     # Mock realtime pipeline manager with one alive pipeline
     mock_pipeline = MagicMock()
@@ -36,6 +40,7 @@ def mock_app():
 @pytest.fixture
 def client(mock_app):
     from fastapi import FastAPI
+
     test_app = FastAPI()
     test_app.include_router(calibration_router)
 
@@ -53,18 +58,21 @@ def client(mock_app):
 class TestCalibrationRecordingStatePublishing:
     def test_start_publishes_recording_state(self, client, mock_app):
         """POST /calibration/recording/start publishes is_active=True."""
-        response = client.post("/calibration/recording/start", json={
-            "calibrationTaskConfig": {
-                "charucoBoard": {
-                    "squares_x": 7,
-                    "squares_y": 5,
-                    "square_length_mm": 54,
-                    "marker_length_ratio": 0.8,
-                    "aruco_dictionary_enum": 10,  # cv2.aruco.DICT_4X4_250
-                }
+        response = client.post(
+            "/calibration/recording/start",
+            json={
+                "calibrationTaskConfig": {
+                    "charucoBoard": {
+                        "squares_x": 7,
+                        "squares_y": 5,
+                        "square_length_mm": 54,
+                        "marker_length_ratio": 0.8,
+                        "aruco_dictionary_enum": 10,  # cv2.aruco.DICT_4X4_250
+                    }
+                },
+                "calibrationRecordingDirectory": "/tmp/test",
             },
-            "calibrationRecordingDirectory": "/tmp/test",
-        })
+        )
         assert response.status_code == 200
 
         # Verify publish was called on each alive pipeline
@@ -77,19 +85,64 @@ class TestCalibrationRecordingStatePublishing:
             assert isinstance(call_args[0][1], CalibrationRecordingStateMessage)
             assert call_args[0][1].is_active is True
 
+
+class TestCalibrationStatus:
+    def test_missing_calibration_is_explicit(self, client, tmp_path):
+        with patch(
+            "freemocap.api.http.calibration.calibration_router.get_last_successful_calibration_toml_path",
+            return_value=tmp_path / "missing.toml",
+        ):
+            response = client.get("/calibration/status")
+        assert response.status_code == 200
+        assert response.json() == {
+            "state": "missing",
+            "path": None,
+            "camera_ids": [],
+            "reprojection_error_px": None,
+            "accepted": False,
+            "updated_at_ms": None,
+            "error": None,
+        }
+
+    def test_reports_camera_set_and_quality_threshold(self, client, tmp_path):
+        calibration_path = tmp_path / "calibration.toml"
+        calibration_path.write_text("fixture")
+        calibration = MagicMock(
+            camera_ids=["cam-a", "cam-b"], reprojection_error_px=1.25
+        )
+        with (
+            patch(
+                "freemocap.api.http.calibration.calibration_router.get_last_successful_calibration_toml_path",
+                return_value=calibration_path,
+            ),
+            patch(
+                "freemocap.api.http.calibration.calibration_router.CalibrationResult.load_anipose_toml",
+                return_value=calibration,
+            ),
+        ):
+            response = client.get("/calibration/status")
+        assert response.status_code == 200
+        assert response.json()["state"] == "ready"
+        assert response.json()["camera_ids"] == ["cam-a", "cam-b"]
+        assert response.json()["reprojection_error_px"] == 1.25
+        assert response.json()["accepted"] is True
+
     def test_stop_publishes_recording_state(self, client, mock_app):
         """POST /calibration/recording/stop publishes is_active=False."""
-        response = client.post("/calibration/recording/stop", json={
-            "calibrationTaskConfig": {
-                "charucoBoard": {
-                    "squares_x": 7,
-                    "squares_y": 5,
-                    "square_length_mm": 54,
-                    "marker_length_ratio": 0.8,
-                    "aruco_dictionary_enum": 10,  # cv2.aruco.DICT_4X4_250
-                }
+        response = client.post(
+            "/calibration/recording/stop",
+            json={
+                "calibrationTaskConfig": {
+                    "charucoBoard": {
+                        "squares_x": 7,
+                        "squares_y": 5,
+                        "square_length_mm": 54,
+                        "marker_length_ratio": 0.8,
+                        "aruco_dictionary_enum": 10,  # cv2.aruco.DICT_4X4_250
+                    }
+                },
             },
-        })
+        )
         assert response.status_code == 200
 
         # Verify publish was called on each alive pipeline

--- a/freemocap/tests/test_binary_keypoints_protocol.py
+++ b/freemocap/tests/test_binary_keypoints_protocol.py
@@ -188,3 +188,35 @@ def test_tracker_id_truncates_safely_on_overlong_input():
         dtype=KEYPOINTS_BLOCK_HEADER_DTYPE,
     )[0]
     assert block_header["tracker_id"] == b"x" * 32
+
+
+def test_multi_person_skeleton_blocks_keep_stable_performer_ids():
+    performers = {
+        "performer-1": {"left_hip": np.array([-1.0, 2.0, 3.0])},
+        "performer-2": {"left_hip": np.array([1.0, 2.0, 3.0])},
+    }
+    blob = build_keypoints_payload(
+        frame_number=12,
+        tracker_id="rtmpose_wholebody",
+        point_names=POINT_NAMES,
+        keypoints_arrays={},
+        performer_skeleton_arrays=performers,
+    )
+    buf = bytes(blob)
+    header = np.frombuffer(
+        buf[:PAYLOAD_HEADER_SIZE], dtype=KEYPOINTS_PAYLOAD_HEADER_FOOTER_DTYPE
+    )[0]
+    assert int(header["num_blocks"]) == 3
+
+    cursor = PAYLOAD_HEADER_SIZE
+    performer_ids = []
+    for block_index in range(3):
+        block = np.frombuffer(
+            buf[cursor:cursor + BLOCK_HEADER_SIZE], dtype=KEYPOINTS_BLOCK_HEADER_DTYPE
+        )[0]
+        if block_index > 0:
+            assert int(block["block_kind"]) == int(BlockKind.SKELETON_3D)
+            performer_ids.append(block["camera_id"].decode("ascii").rstrip("\x00"))
+        cursor += BLOCK_HEADER_SIZE + int(block["data_byte_length"])
+
+    assert performer_ids == ["performer-1", "performer-2"]

--- a/freemocap/tests/test_multi_person_association.py
+++ b/freemocap/tests/test_multi_person_association.py
@@ -1,15 +1,19 @@
 import numpy as np
 
 from freemocap.core.tracking.multi_person_association import (
+    CrossCameraAssociator,
     PersonDescriptor,
     appearance_histogram,
     associate_two_person_views,
     bone_length_signature,
     performer_parquet_rows,
 )
+from freemocap.core.pipeline.realtime.camera_node_config import CameraNodeConfig
 
 
-def _descriptor(identifier: str, x: float, signature: list[float], colour_bin: int) -> PersonDescriptor:
+def _descriptor(
+    identifier: str, x: float, signature: list[float], colour_bin: int
+) -> PersonDescriptor:
     histogram = np.zeros(512)
     histogram[colour_bin] = 1.0
     return PersonDescriptor(
@@ -55,3 +59,41 @@ def test_features_and_parquet_rows_include_performer_id():
     assert np.isfinite(bone_length_signature(points)).all()
     rows = performer_parquet_rows(4, {"performer-1": points})
     assert {row["performer_id"] for row in rows} == {"performer-1"}
+
+
+def test_cross_camera_associator_preserves_primary_ids_when_detector_order_flips():
+    zero_hist = np.zeros(512, dtype=np.float64)
+
+    def descriptor(identity: str, signature: float) -> PersonDescriptor:
+        return PersonDescriptor(identity, np.zeros(3), np.array([signature]), zero_hist)
+
+    associator = CrossCameraAssociator()
+    first = associator.assign(
+        {
+            "cam-a": [descriptor("track-a", 0.1), descriptor("track-b", 0.9)],
+            "cam-b": [descriptor("other-b", 0.9), descriptor("other-a", 0.1)],
+        }
+    )
+    assert first == {
+        "performer-1": {"cam-a": "track-a", "cam-b": "other-a"},
+        "performer-2": {"cam-a": "track-b", "cam-b": "other-b"},
+    }
+    second = associator.assign(
+        {
+            "cam-a": [descriptor("track-b", 0.9), descriptor("track-a", 0.1)],
+            "cam-b": [descriptor("other-a", 0.1), descriptor("other-b", 0.9)],
+        }
+    )
+    assert second["performer-1"]["cam-a"] == "track-a"
+    assert second["performer-2"]["cam-a"] == "track-b"
+
+
+def test_multi_person_config_uses_the_selected_lightweight_model():
+    config = CameraNodeConfig(
+        multi_person_enabled=True,
+        rtmpose_model_name="rtmw-l-m_256x192",
+        rtmpose_confidence_threshold=0.01,
+    )
+    detector = config.skeleton_tracker_config.stages[0].keypoint_detectors[0]
+    assert detector.model_name == "rtmw-l-m_256x192"
+    assert detector.confidence_threshold == 0.01

--- a/freemocap/tests/test_multi_person_association.py
+++ b/freemocap/tests/test_multi_person_association.py
@@ -1,0 +1,57 @@
+import numpy as np
+
+from freemocap.core.tracking.multi_person_association import (
+    PersonDescriptor,
+    appearance_histogram,
+    associate_two_person_views,
+    bone_length_signature,
+    performer_parquet_rows,
+)
+
+
+def _descriptor(identifier: str, x: float, signature: list[float], colour_bin: int) -> PersonDescriptor:
+    histogram = np.zeros(512)
+    histogram[colour_bin] = 1.0
+    return PersonDescriptor(
+        detection_id=identifier,
+        pelvis=np.array([x, 0.0, 0.0]),
+        bone_signature=np.asarray(signature),
+        appearance_histogram=histogram,
+    )
+
+
+def test_cross_camera_order_change_preserves_two_identities():
+    references = [
+        _descriptor("performer-1", -100.0, [0.8, 1.2], 4),
+        _descriptor("performer-2", 100.0, [1.3, 0.7], 400),
+    ]
+    candidates = [
+        _descriptor("camera-b-track-9", 110.0, [1.3, 0.7], 400),
+        _descriptor("camera-b-track-2", -90.0, [0.8, 1.2], 4),
+    ]
+    assert associate_two_person_views(references, candidates) == {
+        "performer-1": "camera-b-track-2",
+        "performer-2": "camera-b-track-9",
+    }
+
+
+def test_ambiguous_identity_is_held_instead_of_swapped():
+    identical = [1.0, 1.0]
+    references = [_descriptor("performer-1", 0, identical, 10)]
+    candidates = [
+        _descriptor("candidate-a", -1, identical, 10),
+        _descriptor("candidate-b", 1, identical, 10),
+    ]
+    assert associate_two_person_views(references, candidates) == {}
+
+
+def test_features_and_parquet_rows_include_performer_id():
+    image = np.full((4, 4, 3), [255, 0, 0], dtype=np.uint8)
+    assert appearance_histogram(image, (0, 0, 4, 4)).sum() == 1.0
+    points = {
+        "left_hip": np.array([-1.0, 0.0, 0.0]),
+        "right_hip": np.array([1.0, 0.0, 0.0]),
+    }
+    assert np.isfinite(bone_length_signature(points)).all()
+    rows = performer_parquet_rows(4, {"performer-1": points})
+    assert {row["performer_id"] for row in rows} == {"performer-1"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ cpu = ["skellytracker[all-cpu]"]
 
 [tool.uv.sources]
 skellycam = { git = "https://github.com/freemocap/skellycam", branch = "main" }
-skellytracker = { git = "https://github.com/freemocap/skellytracker", branch = "main"}
+skellytracker = { git = "https://github.com/achmadawdi/skellytracker", rev = "950c08f34540d92d38869ddcf102029f0105740a"}
 skellyforge = { git = "https://github.com/freemocap/skellyforge", branch = "main" }
 freemocap_blender_addon = { git = "https://github.com/freemocap/freemocap_blender_addon", branch = "main" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,10 +3,10 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32'",
 ]
 supported-markers = [
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "freemocap"
-version = "2.0.0a20"
+version = "2.0.0a21"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },
@@ -446,15 +446,15 @@ requires-dist = [
     { name = "skellyforge", git = "https://github.com/freemocap/skellyforge?branch=main" },
     { name = "skellylogs", git = "https://github.com/freemocap/skellylogs" },
     { name = "skellypings", git = "https://github.com/freemocap/skellypings" },
-    { name = "skellytracker", extras = ["all-cpu"], marker = "extra == 'cpu'", git = "https://github.com/freemocap/skellytracker?branch=main" },
-    { name = "skellytracker", extras = ["all-cuda"], marker = "extra == 'cuda'", git = "https://github.com/freemocap/skellytracker?branch=main" },
+    { name = "skellytracker", extras = ["all-cpu"], marker = "extra == 'cpu'", git = "https://github.com/achmadawdi/skellytracker?rev=950c08f34540d92d38869ddcf102029f0105740a" },
+    { name = "skellytracker", extras = ["all-cuda"], marker = "extra == 'cuda'", git = "https://github.com/achmadawdi/skellytracker?rev=950c08f34540d92d38869ddcf102029f0105740a" },
     { name = "tomli-w", specifier = ">=1.2.0" },
 ]
 provides-extras = ["cuda", "cpu"]
 
 [package.metadata.requires-dev]
-cpu = [{ name = "skellytracker", extras = ["all-cpu"], git = "https://github.com/freemocap/skellytracker?branch=main" }]
-cuda = [{ name = "skellytracker", extras = ["all-cuda"], git = "https://github.com/freemocap/skellytracker?branch=main" }]
+cpu = [{ name = "skellytracker", extras = ["all-cpu"], git = "https://github.com/achmadawdi/skellytracker?rev=950c08f34540d92d38869ddcf102029f0105740a" }]
+cuda = [{ name = "skellytracker", extras = ["all-cuda"], git = "https://github.com/achmadawdi/skellytracker?rev=950c08f34540d92d38869ddcf102029f0105740a" }]
 dev = [
     { name = "bumpver" },
     { name = "httpx", specifier = ">=0.28.0" },
@@ -468,8 +468,8 @@ dev = [
 ]
 pyceres = [{ name = "pyceres", specifier = ">=2.5" }]
 tracker-default = [
-    { name = "skellytracker", extras = ["all-cpu"], marker = "sys_platform == 'darwin'", git = "https://github.com/freemocap/skellytracker?branch=main" },
-    { name = "skellytracker", extras = ["all-cuda"], marker = "sys_platform != 'darwin'", git = "https://github.com/freemocap/skellytracker?branch=main" },
+    { name = "skellytracker", extras = ["all-cpu"], marker = "sys_platform == 'darwin'", git = "https://github.com/achmadawdi/skellytracker?rev=950c08f34540d92d38869ddcf102029f0105740a" },
+    { name = "skellytracker", extras = ["all-cuda"], marker = "sys_platform != 'darwin'", git = "https://github.com/achmadawdi/skellytracker?rev=950c08f34540d92d38869ddcf102029f0105740a" },
 ]
 
 [[package]]
@@ -1988,7 +1988,7 @@ dependencies = [
 [[package]]
 name = "skellytracker"
 version = "2024.9.1019"
-source = { git = "https://github.com/freemocap/skellytracker?branch=main#7a8f80ce3d59ceccd01a215add72c2e6e26e767b" }
+source = { git = "https://github.com/achmadawdi/skellytracker?rev=950c08f34540d92d38869ddcf102029f0105740a#950c08f34540d92d38869ddcf102029f0105740a" }
 dependencies = [
     { name = "beartype" },
     { name = "numpy" },


### PR DESCRIPTION
Adds opt-in two-person realtime tracking while keeping the existing single-person path and payload as defaults. The centralized inference node shares one ONNX session, maintains per-camera tracks, associates stable performer IDs across cameras, triangulates each performer independently, emits additive binary and overlay payloads, preserves performer_id in Parquet helpers, and exposes calibration camera-set/quality status. Includes crossing/reorder and payload regressions plus calibration-status tests. Depends on draft freemocap/skellytracker#83; this branch pins the compatible fork commit for validation. This is an early draft for architecture and performance feedback.